### PR TITLE
fix(deps): add @neon-rs/load to nativemodules.json

### DIFF
--- a/nativemodules.json
+++ b/nativemodules.json
@@ -1,6 +1,7 @@
 [
   "font-list",
   "7z-wasm",
+  "@neon-rs/load",
   "@open-orpheus/database",
   "@open-orpheus/window",
   "@open-orpheus/ui"


### PR DESCRIPTION
The @neon-rs/load module is required by @open-orpheus/* native modules at runtime but was missing from the packaged dependencies.