### PR TITLE
修复Linux下User-Agent错误

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -174,8 +174,8 @@ app.on("ready", async () => {
     if (os.platform() === "linux") {
       // Make some modules think we are indeed on desktop.
       userAgent = userAgent.replace(
-        /^(Mozilla\/5\.0 \(([^)]*)\))/,
-        "Mozilla/5.0 ($2; Windows NT 10.0; WOW64)"
+        /^(Mozilla\/5\.0 \([^)]*\))/,
+        "Mozilla/5.0 (Windows NT 10.0; WOW64)"
       );
     }
     session.defaultSession.setUserAgent(


### PR DESCRIPTION
close #68 
修复前请求 UA 开头是 `Mozilla/5.0 (X11; Linux x86_64; Windows NT 10.0; WOW64)`
导致无法关注歌手/部分接口异常
修复后开头变为 `Mozilla/5.0 (Windows NT 10.0; WOW64)`