### PR TITLE
修复 anonimous api 400 的问题

### DIFF
--- a/src/main/anonymous.ts
+++ b/src/main/anonymous.ts
@@ -4,7 +4,11 @@ import type { NetworkFetchRequest } from "./calls/network";
 import { deserialData, encodeAnonymousId } from "./crypto";
 import client from "./request";
 
-const MAX_ANONYMOUS_REGISTER_ATTEMPTS = 10;
+const ANONYMOUS_REGISTER_PATH = "/api/register/anonimous";
+const ANONYMOUS_EAPI_REGISTER_PATH = "/eapi/register/anonimous";
+const MUSIC_ORIGIN = "https://music.163.com";
+const ANONYMOUS_REGISTER_API_URL = `${MUSIC_ORIGIN}${ANONYMOUS_REGISTER_PATH}`;
+const MAX_ANONYMOUS_REGISTER_ATTEMPTS = 15;
 
 function createAnonymousUsername() {
   const id = randomBytes(26).toString("hex").toUpperCase();
@@ -18,7 +22,8 @@ function isAnonymousRegisterRequest(url: string) {
     const parsed = new URL(url);
     return (
       parsed.hostname.endsWith("music.163.com") &&
-      parsed.pathname.endsWith("api/register/anonimous")
+      (parsed.pathname === ANONYMOUS_REGISTER_PATH ||
+        parsed.pathname === ANONYMOUS_EAPI_REGISTER_PATH)
     );
   } catch {
     return false;
@@ -32,6 +37,14 @@ type Response = {
   status: number;
 };
 
+function parseResponseCode(blob: string) {
+  try {
+    return JSON.parse(blob)?.code;
+  } catch {
+    return undefined;
+  }
+}
+
 export default async function interceptAnonymousRequest(
   request: NetworkFetchRequest
 ): Promise<[Response | Error, number, number] | null> {
@@ -40,7 +53,10 @@ export default async function interceptAnonymousRequest(
   let sucCount = 0,
     failCount = 0;
 
-  async function doRequest(request: NetworkFetchRequest): Promise<Response> {
+  async function doRequest(
+    request: NetworkFetchRequest,
+    decrypt = Boolean(request.isDecrypt)
+  ): Promise<Response> {
     const response = await client(request.url, {
       method: request.method,
       headers: {
@@ -55,7 +71,7 @@ export default async function interceptAnonymousRequest(
       hooks: {
         beforeRetry: [
           () => {
-            sucCount++;
+            failCount++;
           },
         ],
       },
@@ -71,7 +87,7 @@ export default async function interceptAnonymousRequest(
     }
 
     const responseBody = Buffer.from(response.rawBody);
-    const blob = request.isDecrypt
+    const blob = decrypt
       ? deserialData(
           responseBody.buffer.slice(
             responseBody.byteOffset,
@@ -80,7 +96,7 @@ export default async function interceptAnonymousRequest(
         )
       : responseBody.toString();
 
-    failCount++;
+    sucCount++;
 
     return {
       blob,
@@ -94,23 +110,37 @@ export default async function interceptAnonymousRequest(
     // Let's do the first request directly
     const res = await doRequest(request);
 
-    const resJson = JSON.parse(res.blob);
-    if (resJson.code === 400) {
+    if (parseResponseCode(res.blob) === 400) {
       // Oops, failed, run the attempts
-      request.url = "https://music.163.com/api/register/anonimous";
+      let lastRes = res;
       for (
         let attempt = 2;
-        attempt < MAX_ANONYMOUS_REGISTER_ATTEMPTS;
+        attempt <= MAX_ANONYMOUS_REGISTER_ATTEMPTS;
         attempt++
       ) {
-        request.body = new URLSearchParams({
-          username: createAnonymousUsername(),
-        }).toString();
-        const res = await doRequest(request);
-        const resJson = JSON.parse(res.blob);
-        if (resJson.code === 400) continue;
+        const res = await doRequest(
+          {
+            ...request,
+            url: ANONYMOUS_REGISTER_API_URL,
+            method: "POST",
+            headers: {
+              Accept: "*/*",
+              "Content-Type": "application/x-www-form-urlencoded",
+              Referer: `${MUSIC_ORIGIN}/`,
+            },
+            body: new URLSearchParams({
+              username: createAnonymousUsername(),
+            }).toString(),
+            retryCount: 0,
+            isDecrypt: false,
+          },
+          false
+        );
+        lastRes = res;
+        if (parseResponseCode(res.blob) === 400) continue;
         return [res, sucCount, failCount];
       }
+      return [lastRes, sucCount, failCount];
     }
 
     return [res, sucCount, failCount];

--- a/src/main/anonymous.ts
+++ b/src/main/anonymous.ts
@@ -1,0 +1,126 @@
+import { randomBytes } from "node:crypto";
+
+import type { NetworkFetchRequest } from "./calls/network";
+import { deserialData, encodeAnonymousId } from "./crypto";
+import client from "./request";
+
+const MAX_ANONYMOUS_REGISTER_ATTEMPTS = 10;
+
+function createAnonymousUsername() {
+  const id = randomBytes(26).toString("hex").toUpperCase();
+  return Buffer.from(`${id} ${encodeAnonymousId(id)}`, "utf8").toString(
+    "base64"
+  );
+}
+
+function isAnonymousRegisterRequest(url: string) {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.hostname.endsWith("music.163.com") &&
+      parsed.pathname.endsWith("api/register/anonimous")
+    );
+  } catch {
+    return false;
+  }
+}
+
+type Response = {
+  blob: string;
+  retryTimes: number;
+  headers: Record<string, string>;
+  status: number;
+};
+
+export default async function interceptAnonymousRequest(
+  request: NetworkFetchRequest
+): Promise<[Response | Error, number, number] | null> {
+  if (!isAnonymousRegisterRequest(request.url)) return null;
+
+  let sucCount = 0,
+    failCount = 0;
+
+  async function doRequest(request: NetworkFetchRequest): Promise<Response> {
+    const response = await client(request.url, {
+      method: request.method,
+      headers: {
+        ...request.headers,
+      },
+      body: request.body || undefined,
+      throwHttpErrors: false,
+      retry: {
+        limit: request.retryCount,
+        backoffLimit: 10000,
+      },
+      hooks: {
+        beforeRetry: [
+          () => {
+            sucCount++;
+          },
+        ],
+      },
+    });
+
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(response.headers)) {
+      if (Array.isArray(value)) {
+        headers[key] = value.join(", ");
+      } else if (value !== undefined) {
+        headers[key] = value;
+      }
+    }
+
+    const responseBody = Buffer.from(response.rawBody);
+    const blob = request.isDecrypt
+      ? deserialData(
+          responseBody.buffer.slice(
+            responseBody.byteOffset,
+            responseBody.byteOffset + responseBody.byteLength
+          )
+        )
+      : responseBody.toString();
+
+    failCount++;
+
+    return {
+      blob,
+      retryTimes: 0,
+      headers,
+      status: response.statusCode,
+    };
+  }
+
+  try {
+    // Let's do the first request directly
+    const res = await doRequest(request);
+
+    const resJson = JSON.parse(res.blob);
+    if (resJson.code === 400) {
+      // Oops, failed, run the attempts
+      request.url = "https://music.163.com/api/register/anonimous";
+      for (
+        let attempt = 2;
+        attempt < MAX_ANONYMOUS_REGISTER_ATTEMPTS;
+        attempt++
+      ) {
+        request.body = new URLSearchParams({
+          username: createAnonymousUsername(),
+        }).toString();
+        const res = await doRequest(request);
+        const resJson = JSON.parse(res.blob);
+        if (resJson.code === 400) continue;
+        return [res, sucCount, failCount];
+      }
+    }
+
+    return [res, sucCount, failCount];
+  } catch (err) {
+    let e: Error;
+    if (err instanceof Error) {
+      e = err;
+    } else {
+      e = new Error(String(err));
+    }
+    return [e, sucCount, failCount];
+  }
+}

--- a/src/main/anonymous.ts
+++ b/src/main/anonymous.ts
@@ -1,3 +1,11 @@
+/*
+Our requests to /register/anonimous API are still problematic (server returns 400),
+this module is used to workaround it. Tho it's quite hacky, but it works, confirmed
+by our tests.
+We are still looking to solve the 400 issue properly.
+See https://github.com/YUCLing/open-orpheus/pull/75
+*/
+
 import { randomBytes } from "node:crypto";
 
 import type { NetworkFetchRequest } from "./calls/network";

--- a/src/main/calls/network.ts
+++ b/src/main/calls/network.ts
@@ -1,22 +1,15 @@
 import dns from "node:dns";
-import { randomBytes } from "node:crypto";
 
 import { RequestError } from "got";
 import type { Method } from "got";
 
 import { registerCallHandler } from "../calls";
-import { getCookies } from "../cookie";
-import { deserialData, encodeAnonymousId } from "../crypto";
+import { deserialData } from "../crypto";
 import client from "../request";
+import interceptAnonymousRequest from "../anonymous";
 
 let globalFailCount = 0;
 let globalSucCount = 0;
-
-const ANONYMOUS_REGISTER_PATH = "/api/register/anonimous";
-const MUSIC_ORIGIN = "https://music.163.com";
-const ANONYMOUS_REGISTER_API_URL = `${MUSIC_ORIGIN}${ANONYMOUS_REGISTER_PATH}`;
-const MUSIC_A_COOKIE_NAME = "MUSIC_A";
-const MAX_ANONYMOUS_REGISTER_ATTEMPTS = 10;
 
 export type NetworkFetchRequest = {
   url: string;
@@ -39,133 +32,48 @@ export type NetworkFetchResponse = {
   blob: string;
 }>;
 
-function isAnonymousRegisterRequest(url: string) {
-  try {
-    const parsed = new URL(url);
-    return (
-      parsed.hostname.endsWith("music.163.com") &&
-      (parsed.pathname === ANONYMOUS_REGISTER_PATH ||
-        parsed.pathname === "/eapi/register/anonimous")
-    );
-  } catch {
-    return false;
-  }
-}
-
-function createAnonymousUsername() {
-  const id = randomBytes(26).toString("hex").toUpperCase();
-  return Buffer.from(`${id} ${encodeAnonymousId(id)}`, "utf8").toString(
-    "base64"
-  );
-}
-
-function responseBodyToBlob(
-  request: NetworkFetchRequest,
-  responseBody: Buffer<ArrayBufferLike>
-) {
-  return request.isDecrypt
-    ? deserialData(
-        responseBody.buffer.slice(
-          responseBody.byteOffset,
-          responseBody.byteOffset + responseBody.byteLength
-        ) as ArrayBuffer
-      )
-    : responseBody.toString();
-}
-
-function parseResponseCode(blob: string) {
-  try {
-    return JSON.parse(blob)?.code;
-  } catch {
-    return undefined;
-  }
-}
-
-async function getMusicA() {
-  try {
-    const cookies = await getCookies(MUSIC_ORIGIN);
-    return cookies[MUSIC_A_COOKIE_NAME] ?? null;
-  } catch {
-    return null;
-  }
-}
-
-async function logAnonymousRegisterAttempt(attempt: number, code: unknown) {
-  const musicA = await getMusicA();
-  console.info("[anonymous] register", {
-    attempt,
-    code: code ?? null,
-    MUSIC_A: Boolean(musicA),
-  });
-}
-
-async function fetchRequest(request: NetworkFetchRequest, retryCount: number) {
-  return await client(request.url, {
-    method: request.method,
-    headers: {
-      ...request.headers,
-    },
-    body: request.body || undefined,
-    throwHttpErrors: false,
-    retry: {
-      limit: retryCount,
-      backoffLimit: 10000,
-    },
-    hooks: {
-      beforeRetry: [
-        () => {
-          globalFailCount++;
-        },
-      ],
-    },
-  });
-}
-
-async function fetchAnonymousRegister() {
-  return await client.post(ANONYMOUS_REGISTER_API_URL, {
-    headers: {
-      Accept: "*/*",
-      "Content-Type": "application/x-www-form-urlencoded",
-      Referer: `${MUSIC_ORIGIN}/`,
-    },
-    body: new URLSearchParams({
-      username: createAnonymousUsername(),
-    }).toString(),
-    throwHttpErrors: false,
-    retry: {
-      limit: 0,
-    },
-  });
-}
-
 registerCallHandler<[NetworkFetchRequest], [NetworkFetchResponse]>(
   "network.fetch",
   async (_, request): Promise<[NetworkFetchResponse]> => {
     const retryCount = request.retryCount ?? 1;
-    const isAnonymousRegister = isAnonymousRegisterRequest(request.url);
-    let anonymousAttempt = isAnonymousRegister ? 1 : 0;
 
     try {
-      let response = await fetchRequest(request, retryCount);
-      let responseBody = Buffer.from(response.rawBody);
-      let blob = responseBodyToBlob(request, responseBody);
-      let responseCode = parseResponseCode(blob);
-
-      if (isAnonymousRegister) {
-        await logAnonymousRegisterAttempt(1, responseCode);
-        for (
-          let attempt = 2;
-          responseCode === 400 && attempt <= MAX_ANONYMOUS_REGISTER_ATTEMPTS;
-          attempt++
-        ) {
-          anonymousAttempt = attempt;
-          response = await fetchAnonymousRegister();
-          responseBody = Buffer.from(response.rawBody);
-          blob = responseBody.toString();
-          responseCode = parseResponseCode(blob);
-          await logAnonymousRegisterAttempt(attempt, responseCode);
-        }
+      const anonymousRes = await interceptAnonymousRequest(request);
+      if (anonymousRes !== null) {
+        const [res, suc, fail] = anonymousRes;
+        globalSucCount += suc;
+        globalFailCount += fail;
+        if (res instanceof Error) throw res;
+        return [
+          {
+            code: 0,
+            error: "",
+            globalFailCount,
+            globalSucCount,
+            ...res,
+          },
+        ];
       }
+
+      const response = await client(request.url, {
+        method: request.method,
+        headers: {
+          ...request.headers,
+        },
+        body: request.body || undefined,
+        throwHttpErrors: false,
+        retry: {
+          limit: retryCount,
+          backoffLimit: 10000,
+        },
+        hooks: {
+          beforeRetry: [
+            () => {
+              globalFailCount++;
+            },
+          ],
+        },
+      });
 
       const headers: Record<string, string> = {};
       for (const [key, value] of Object.entries(response.headers)) {
@@ -175,6 +83,16 @@ registerCallHandler<[NetworkFetchRequest], [NetworkFetchResponse]>(
           headers[key] = value;
         }
       }
+
+      const responseBody = Buffer.from(response.rawBody);
+      const blob = request.isDecrypt
+        ? deserialData(
+            responseBody.buffer.slice(
+              responseBody.byteOffset,
+              responseBody.byteOffset + responseBody.byteLength
+            )
+          )
+        : responseBody.toString();
 
       globalSucCount++;
 
@@ -191,16 +109,6 @@ registerCallHandler<[NetworkFetchRequest], [NetworkFetchResponse]>(
         },
       ];
     } catch (error) {
-      if (isAnonymousRegister) {
-        await logAnonymousRegisterAttempt(anonymousAttempt, null);
-        console.warn("[anonymous] register failed", {
-          attempt: anonymousAttempt,
-          error:
-            (error as Error)?.message ||
-            (error ? String(error) : "Unknown error"),
-        });
-      }
-
       globalFailCount++;
       const retryTimes =
         error instanceof RequestError && error.request

--- a/src/main/calls/network.ts
+++ b/src/main/calls/network.ts
@@ -1,14 +1,22 @@
 import dns from "node:dns";
+import { randomBytes } from "node:crypto";
 
 import { RequestError } from "got";
 import type { Method } from "got";
 
 import { registerCallHandler } from "../calls";
-import { deserialData } from "../crypto";
+import { getCookies } from "../cookie";
+import { deserialData, encodeAnonymousId } from "../crypto";
 import client from "../request";
 
 let globalFailCount = 0;
 let globalSucCount = 0;
+
+const ANONYMOUS_REGISTER_PATH = "/api/register/anonimous";
+const MUSIC_ORIGIN = "https://music.163.com";
+const ANONYMOUS_REGISTER_API_URL = `${MUSIC_ORIGIN}${ANONYMOUS_REGISTER_PATH}`;
+const MUSIC_A_COOKIE_NAME = "MUSIC_A";
+const MAX_ANONYMOUS_REGISTER_ATTEMPTS = 10;
 
 export type NetworkFetchRequest = {
   url: string;
@@ -31,31 +39,133 @@ export type NetworkFetchResponse = {
   blob: string;
 }>;
 
+function isAnonymousRegisterRequest(url: string) {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.hostname.endsWith("music.163.com") &&
+      (parsed.pathname === ANONYMOUS_REGISTER_PATH ||
+        parsed.pathname === "/eapi/register/anonimous")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function createAnonymousUsername() {
+  const id = randomBytes(26).toString("hex").toUpperCase();
+  return Buffer.from(`${id} ${encodeAnonymousId(id)}`, "utf8").toString(
+    "base64"
+  );
+}
+
+function responseBodyToBlob(
+  request: NetworkFetchRequest,
+  responseBody: Buffer<ArrayBufferLike>
+) {
+  return request.isDecrypt
+    ? deserialData(
+        responseBody.buffer.slice(
+          responseBody.byteOffset,
+          responseBody.byteOffset + responseBody.byteLength
+        ) as ArrayBuffer
+      )
+    : responseBody.toString();
+}
+
+function parseResponseCode(blob: string) {
+  try {
+    return JSON.parse(blob)?.code;
+  } catch {
+    return undefined;
+  }
+}
+
+async function getMusicA() {
+  try {
+    const cookies = await getCookies(MUSIC_ORIGIN);
+    return cookies[MUSIC_A_COOKIE_NAME] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function logAnonymousRegisterAttempt(attempt: number, code: unknown) {
+  const musicA = await getMusicA();
+  console.info("[anonymous] register", {
+    attempt,
+    code: code ?? null,
+    MUSIC_A: Boolean(musicA),
+  });
+}
+
+async function fetchRequest(request: NetworkFetchRequest, retryCount: number) {
+  return await client(request.url, {
+    method: request.method,
+    headers: {
+      ...request.headers,
+    },
+    body: request.body || undefined,
+    throwHttpErrors: false,
+    retry: {
+      limit: retryCount,
+      backoffLimit: 10000,
+    },
+    hooks: {
+      beforeRetry: [
+        () => {
+          globalFailCount++;
+        },
+      ],
+    },
+  });
+}
+
+async function fetchAnonymousRegister() {
+  return await client.post(ANONYMOUS_REGISTER_API_URL, {
+    headers: {
+      Accept: "*/*",
+      "Content-Type": "application/x-www-form-urlencoded",
+      Referer: `${MUSIC_ORIGIN}/`,
+    },
+    body: new URLSearchParams({
+      username: createAnonymousUsername(),
+    }).toString(),
+    throwHttpErrors: false,
+    retry: {
+      limit: 0,
+    },
+  });
+}
+
 registerCallHandler<[NetworkFetchRequest], [NetworkFetchResponse]>(
   "network.fetch",
   async (_, request): Promise<[NetworkFetchResponse]> => {
     const retryCount = request.retryCount ?? 1;
+    const isAnonymousRegister = isAnonymousRegisterRequest(request.url);
+    let anonymousAttempt = isAnonymousRegister ? 1 : 0;
 
     try {
-      const response = await client(request.url, {
-        method: request.method,
-        headers: {
-          ...request.headers,
-        },
-        body: request.body || undefined,
-        throwHttpErrors: false,
-        retry: {
-          limit: retryCount,
-          backoffLimit: 10000,
-        },
-        hooks: {
-          beforeRetry: [
-            () => {
-              globalFailCount++;
-            },
-          ],
-        },
-      });
+      let response = await fetchRequest(request, retryCount);
+      let responseBody = Buffer.from(response.rawBody);
+      let blob = responseBodyToBlob(request, responseBody);
+      let responseCode = parseResponseCode(blob);
+
+      if (isAnonymousRegister) {
+        await logAnonymousRegisterAttempt(1, responseCode);
+        for (
+          let attempt = 2;
+          responseCode === 400 && attempt <= MAX_ANONYMOUS_REGISTER_ATTEMPTS;
+          attempt++
+        ) {
+          anonymousAttempt = attempt;
+          response = await fetchAnonymousRegister();
+          responseBody = Buffer.from(response.rawBody);
+          blob = responseBody.toString();
+          responseCode = parseResponseCode(blob);
+          await logAnonymousRegisterAttempt(attempt, responseCode);
+        }
+      }
 
       const headers: Record<string, string> = {};
       for (const [key, value] of Object.entries(response.headers)) {
@@ -65,16 +175,6 @@ registerCallHandler<[NetworkFetchRequest], [NetworkFetchResponse]>(
           headers[key] = value;
         }
       }
-
-      const responseBody = Buffer.from(response.rawBody);
-      const blob = request.isDecrypt
-        ? deserialData(
-            responseBody.buffer.slice(
-              responseBody.byteOffset,
-              responseBody.byteOffset + responseBody.byteLength
-            )
-          )
-        : responseBody.toString();
 
       globalSucCount++;
 
@@ -91,6 +191,16 @@ registerCallHandler<[NetworkFetchRequest], [NetworkFetchResponse]>(
         },
       ];
     } catch (error) {
+      if (isAnonymousRegister) {
+        await logAnonymousRegisterAttempt(anonymousAttempt, null);
+        console.warn("[anonymous] register failed", {
+          attempt: anonymousAttempt,
+          error:
+            (error as Error)?.message ||
+            (error ? String(error) : "Unknown error"),
+        });
+      }
+
       globalFailCount++;
       const retryTimes =
         error instanceof RequestError && error.request


### PR DESCRIPTION
Windows 版本的 CloudMusic 的匿名态主要由 `MUSIC_A cookie` 表示，存放在 `Chromium/CEF` 的 Cookie DB：`/abs/path/not-applicable`，其实际路径为：`$APPDATA$\Local\NetEase\CloudMusic\webapp91x64\Cookies`

本次改动把网易云认证态拆成两层：`MUSIC_U`(登录用户态) 与 `MUSIC_A` (匿名用户态)，当前 Windows  3.1.31 版本客户端匿名态主要由 `MUSIC_A` 表示，本次改动通过官方风格的匿名注册接口懒加载地产生自己的 `MUSIC_A`。

当前效果：

未登录状态下，如果某个网易云 API 因缺少或过期匿名身份返回 400，Open Orpheus 会自动注册匿名会话，拿到并保存 `MUSIC_A`，然后重试原请求。后续请求会通过已有 cookie 管线自动带上 `MUSIC_A`。

截图展示：

<img width="1401" height="992" alt="image" src="https://github.com/user-attachments/assets/0521db84-bf2f-4e89-be2b-a74f2f4bd101" />

---

当前版本修改 Closed #17 