### PR TITLE
fix:  GNOME desktop support for tray menu initialization

### DIFF
--- a/gui/src/routes/Tray.svelte
+++ b/gui/src/routes/Tray.svelte
@@ -9,7 +9,8 @@
   type TrayClickBehavior =
     | "depends-on-main-window"
     | "always-show-menu"
-    | "with-native-menu";
+    | "with-native-menu"
+    | "with-native-menu-gnome";
 
   let clickBehaviorPromise = $state(kv.get("tray.clickBehavior"));
 </script>
@@ -48,7 +49,7 @@
           <Field.Content>
             <Field.Title>总是显示菜单</Field.Title>
             <Field.Description>
-              无论主窗口状态如何，点击托盘图标都会显示菜单。此外，在“退出”上添加“显示主窗口”选项。
+              无论主窗口状态如何，点击托盘图标都会显示菜单。此外，在"退出"上添加"显示主窗口"选项。
             </Field.Description>
           </Field.Content>
           <RadioGroup.Item id="always-show-menu" value="always-show-menu" />
@@ -59,10 +60,21 @@
           <Field.Content>
             <Field.Title>使用原生菜单</Field.Title>
             <Field.Description>
-              无论主窗口状态如何，点击托盘图标都会显示主窗口。右击托盘图标会显示一个原生菜单，仅包含“显示菜单”选项，用于呼出菜单。
+              无论主窗口状态如何，点击托盘图标都会显示主窗口。右击托盘图标会显示一个原生菜单，仅包含"显示菜单"选项，用于呼出菜单。
             </Field.Description>
           </Field.Content>
           <RadioGroup.Item id="with-native-menu" value="with-native-menu" />
+        </Field.Field>
+      </Field.Label>
+      <Field.Label for="with-native-menu-gnome">
+        <Field.Field orientation="horizontal">
+          <Field.Content>
+            <Field.Title>使用原生菜单 Gnome兼容</Field.Title>
+            <Field.Description>
+              适用于 GNOME 桌面环境。点击托盘图标会显示完整的原生菜单，包含播放控制、歌词、设置等选项。需要重启应用程序。
+            </Field.Description>
+          </Field.Content>
+          <RadioGroup.Item id="with-native-menu-gnome" value="with-native-menu-gnome" />
         </Field.Field>
       </Field.Label>
     </RadioGroup.Root>

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@open-orpheus/database": "workspace:*",
     "@open-orpheus/ui": "workspace:*",
     "@open-orpheus/window": "workspace:*",
+    "@resvg/resvg-js": "^2.6.2",
     "@silvia-odwyer/photon-node": "^0.3.4",
     "electron-squirrel-startup": "^1.0.1",
     "music-tag-native": "^0.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@open-orpheus/window':
         specifier: workspace:*
         version: link:modules/window
+      '@resvg/resvg-js':
+        specifier: ^2.6.2
+        version: 2.6.2
       '@silvia-odwyer/photon-node':
         specifier: ^0.3.4
         version: 0.3.4
@@ -972,6 +975,86 @@ packages:
 
   '@reforged/maker-types@2.1.0':
     resolution: {integrity: sha512-gNMAFO6mxqGwuUov0CzXGTHUMfAawlM6v/uYrqVnKeMwmceaLBt3HtfPcuNapDSH4br6D4EZ14WuWbgefmDfOQ==}
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    resolution: {integrity: sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    resolution: {integrity: sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    resolution: {integrity: sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    resolution: {integrity: sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    resolution: {integrity: sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    resolution: {integrity: sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    resolution: {integrity: sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@resvg/resvg-js@2.6.2':
+    resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
+    engines: {node: '>= 10'}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
@@ -5622,6 +5705,57 @@ snapshots:
       - supports-color
 
   '@reforged/maker-types@2.1.0': {}
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js@2.6.2':
+    optionalDependencies:
+      '@resvg/resvg-js-android-arm-eabi': 2.6.2
+      '@resvg/resvg-js-android-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-x64': 2.6.2
+      '@resvg/resvg-js-linux-arm-gnueabihf': 2.6.2
+      '@resvg/resvg-js-linux-arm64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-arm64-musl': 2.6.2
+      '@resvg/resvg-js-linux-x64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-x64-musl': 2.6.2
+      '@resvg/resvg-js-win32-arm64-msvc': 2.6.2
+      '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
+      '@resvg/resvg-js-win32-x64-msvc': 2.6.2
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true

--- a/src/main/calls/trayicon.ts
+++ b/src/main/calls/trayicon.ts
@@ -27,6 +27,15 @@ if (os.platform() === "linux") {
           })
         );
         setMenu(menu);
+        // 切换Gnome菜单，设置占位符菜单建立 D-Bus 通道，然后触发渲染进程加载完整菜单
+      } else if (value === "with-native-menu-gnome") {
+        const placeholder = Menu.buildFromTemplate([
+          { label: "加载中...", enabled: false },
+        ]);
+        setMenu(placeholder);
+        if (mainWindow) {
+          mainWindow.webContents.send("channel.call", "trayicon.onrightclick");
+        }
       } else {
         setMenu(null);
       }

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, screen } from "electron";
+import { BrowserWindow, screen, Menu, type MenuItemConstructorOptions } from "electron";
 import { join, normalize } from "node:path";
 
 import {
@@ -17,6 +17,7 @@ import {
   getMenuWindow,
   getOverlayWindow,
 } from "./menu/windows";
+import { setMenu as setTrayMenu, isGnomeDesktop } from "./tray";
 import packManager from "./pack";
 import SkinPack from "./packs/SkinPack";
 import { registerIpcHandlers } from "../bridge/register";
@@ -58,6 +59,23 @@ export default class AppMenu extends EventTarget {
     this.onClick = handler;
   }
 
+  private buildNativeMenuTemplate(items: AppMenuItem[]): MenuItemConstructorOptions[] {
+    return items.map((item) => {
+      if (item.separator) {
+        return { type: "separator" };
+      }
+      return {
+        label: item.text,
+        enabled: item.enable !== false,
+        submenu: item.children ? this.buildNativeMenuTemplate(item.children) : undefined,
+        click: item.menu_id ? () => {
+          this.onClick?.(item.menu_id!);
+        } : undefined,
+        accelerator: item.hotkey,
+      };
+    });
+  }
+
   /** Collect all distinct style paths from items and load their XML from the skin pack. */
   async loadTemplates() {
     const styles = new Set<string>();
@@ -94,6 +112,23 @@ export default class AppMenu extends EventTarget {
 
   async show() {
     this.closed = false;
+
+    const isGnome = isGnomeDesktop();
+    console.log(`[menu.show] isGnome=${isGnome}, items=${this.items.length}`);
+    if (isGnome) {
+      const template = this.buildNativeMenuTemplate(this.items);
+      console.log(`[menu.show] built native template, ${template.length} entries`);
+      const nativeMenu = Menu.buildFromTemplate(template);
+
+      // Update the tray's context menu via the proper tray module function.
+      // A placeholder menu was already set at tray install time, which established
+      // the AppIndicator D-Bus menu channel. This update replaces the placeholder
+      // (or previous menu) so the next tray click shows the correct items.
+      setTrayMenu(nativeMenu);
+      console.log("[menu.show] setTrayMenu done");
+      return;
+    }
+
     await this.loadTemplates();
 
     if (process.platform === "linux" && isWayland()) {
@@ -111,6 +146,12 @@ export default class AppMenu extends EventTarget {
       this.submenuWindow = null;
     }
 
+    const isGnome = isGnomeDesktop();
+    if (isGnome) {
+      this.dispatchEvent(new Event("close"));
+      return;
+    }
+
     if (process.platform === "linux" && isWayland()) {
       destroyOverlayWindow();
     } else {
@@ -124,6 +165,15 @@ export default class AppMenu extends EventTarget {
     for (const patch of patchItems) {
       if (patch.menu_id == null) continue;
       patchById(this.items, patch);
+    }
+
+    const isGnome = isGnomeDesktop();
+    if (isGnome) {
+
+      const template = this.buildNativeMenuTemplate(this.items);
+      const nativeMenu = Menu.buildFromTemplate(template);
+      setTrayMenu(nativeMenu);
+      return;
     }
 
     if (process.platform === "linux" && isWayland()) {
@@ -212,9 +262,9 @@ export default class AppMenu extends EventTarget {
       close: async () => {
         dismiss();
       },
-      reportSize: async () => {},
-      openSubmenu: async () => {},
-      closeSubmenu: async () => {},
+      reportSize: async () => { },
+      openSubmenu: async () => { },
+      closeSubmenu: async () => { },
     });
   }
 
@@ -302,9 +352,9 @@ export default class AppMenu extends EventTarget {
           });
           sub.showInactive();
         },
-        close: async () => {},
-        openSubmenu: async () => {},
-        closeSubmenu: async () => {},
+        close: async () => { },
+        openSubmenu: async () => { },
+        closeSubmenu: async () => { },
       });
 
       sub.on("blur", () => {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,5 +1,14 @@
-import { BrowserWindow, screen, Menu, type MenuItemConstructorOptions } from "electron";
+import {
+  BrowserWindow,
+  screen,
+  Menu,
+  nativeImage,
+  nativeTheme,
+  type MenuItemConstructorOptions,
+  type NativeImage,
+} from "electron";
 import { join, normalize } from "node:path";
+import { Resvg } from "@resvg/resvg-js";
 
 import {
   captureNextWindowFirstCursorEnter,
@@ -17,15 +26,16 @@ import {
   getMenuWindow,
   getOverlayWindow,
 } from "./menu/windows";
-import { setMenu as setTrayMenu, isGnomeDesktop } from "./tray";
+import { setMenu as setTrayMenu, useGnomeNativeMenu } from "./tray";
 import packManager from "./pack";
+
 import SkinPack from "./packs/SkinPack";
 import { registerIpcHandlers } from "../bridge/register";
 import type { MenuContract } from "../bridge/contracts/menu-api";
 import { parseBtnUrl, parseElementTemplate } from "./skin/dui";
 import type { ElementTemplate } from "./skin/dui";
 
-import type { AppMenuItem } from "$sharedTypes/menu";
+import type { AppMenuItem, AppMenuItemBtn } from "$sharedTypes/menu";
 
 registerMenuSkinUpdater();
 
@@ -49,6 +59,8 @@ export default class AppMenu extends EventTarget {
   private submenuWindow: BrowserWindow | null = null;
   /** style path → parsed template, preloaded from skin pack */
   templates: Record<string, ElementTemplate> = {};
+  /** icon key → NativeImage */
+  private loadedIcons: Record<string, NativeImage> = {};
 
   constructor(public items: AppMenuItem[]) {
     super();
@@ -59,21 +71,138 @@ export default class AppMenu extends EventTarget {
     this.onClick = handler;
   }
 
-  private buildNativeMenuTemplate(items: AppMenuItem[]): MenuItemConstructorOptions[] {
-    return items.map((item) => {
-      if (item.separator) {
-        return { type: "separator" };
+  private btnLabel(btn: AppMenuItemBtn): string {
+    const id = btn.id.toLowerCase();
+
+    if (id.includes("prev")) return "上一首";
+    if (id.includes("next")) return "下一首";
+    if (id.includes("play")) return "播放";
+    if (id.includes("pause")) return "暂停";
+    if (id.includes("stop")) return "停止";
+    if (id.includes("volume") || id.includes("vol")) return "音量";
+    if (id.includes("like") || id.includes("heart")) return "喜欢";
+    if (id.includes("favour") || id.includes("favorite")) return "收藏";
+    if (id.includes("list") || id.includes("playlist")) return "播放列表";
+    if (id.includes("shuffle")) return "随机播放";
+    if (id.includes("repeat")) return "循环播放";
+    if (id.includes("mode")) return "播放模式";
+    return btn.id;
+  }
+
+  private itemLabel(item: AppMenuItem): string {
+    return item.text || "";
+  }
+
+  private async getIcon(item: AppMenuItem | AppMenuItemBtn): Promise<NativeImage | undefined> {
+    const skinPack = packManager.packs.get("skin2")?.isLoaded
+      ? packManager.getPack<SkinPack>("skin2")
+      : await packManager.getOrWaitPack<SkinPack>("skin");
+
+    let iconPath: string | undefined;
+
+    if ("id" in item) {
+      // It's a button
+      const id = item.id.toLowerCase();
+      if (id.includes("prev")) iconPath = "/btn/previous.svg";
+      else if (id.includes("next")) iconPath = "/btn/next.svg";
+      else if (id.includes("play")) iconPath = "/btn/toplay.svg";
+      else if (id.includes("pause")) iconPath = "/btn/topause.svg";
+      else if (id.includes("like")) iconPath = "/btn/love.svg";
+      else if (id.includes("loved")) iconPath = "/btn/loved.svg";
+      else if (id.includes("list")) iconPath = "/btn/showlist.svg";
+    } else {
+      // It's a menu item
+      const text = item.text || "";
+      const path = item.image_path?.toLowerCase() || "";
+      if (path.includes("home") || text.includes("首页")) iconPath = "/lrc/home_normal.svg";
+      else if (path.includes("setting") || text.includes("设置")) iconPath = "/lrc/setting_normal.svg";
+      else if (path.includes("exit") || text.includes("退出") || text.includes("关闭")) iconPath = "/lrc/close_normal.svg";
+      else if (text.includes("歌词")) iconPath = "/mini/shunwang/icon24_lyric_n.png";
+      else if (item.style === "song" || text.includes("正在播放")) iconPath = "/mini/shunwang/logo.png";
+      else if (text.includes("列表")) iconPath = "/btn/showlist.svg";
+      else if (text.includes("模式") || text.includes("完整")) iconPath = "/btn/toweb.svg";
+    }
+
+    if (!iconPath) return undefined;
+    if (this.loadedIcons[iconPath]) return this.loadedIcons[iconPath];
+
+    try {
+      const buf = await skinPack.readFile(normalize(iconPath));
+      let img: NativeImage;
+      if (iconPath.endsWith(".svg")) {
+        // Color SVG according to system theme, then rasterize to PNG
+        let svgStr = buf.toString("utf-8");
+        const color = nativeTheme.shouldUseDarkColors ? "#ffffff" : "#1e1e1e";
+        if (!svgStr.includes("fill=")) {
+          svgStr = svgStr.replace(/<path/g, `<path fill="${color}"`);
+        } else {
+          svgStr = svgStr.replace(/fill="[^"]*"/g, `fill="${color}"`);
+        }
+        const resvg = new Resvg(svgStr, {
+          fitTo: { mode: "width", value: 36 },
+        });
+        const pngData = resvg.render();
+        img = nativeImage.createFromBuffer(pngData.asPng(), { width: 18, height: 18 });
+      } else {
+        img = nativeImage.createFromBuffer(buf).resize({ width: 18, height: 18 });
       }
-      return {
-        label: item.text,
+      this.loadedIcons[iconPath] = img;
+      return img;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async buildNativeMenuTemplate(
+    items: AppMenuItem[]
+  ): Promise<MenuItemConstructorOptions[]> {
+    const result: MenuItemConstructorOptions[] = [];
+
+    for (const item of items) {
+      if (item.separator) {
+        result.push({ type: "separator" });
+        continue;
+      }
+
+      const icon = await this.getIcon(item);
+
+      // Styled items with btns (e.g. playback controls)
+      if (item.style && item.btns?.length) {
+        const btnItems: MenuItemConstructorOptions[] = [];
+        for (const btn of item.btns) {
+          if (btn.enable !== false && btn.images) {
+            btnItems.push({
+              label: this.btnLabel(btn),
+              icon: await this.getIcon(btn),
+              click: () => {
+                this.onClick?.(btn.id);
+              },
+            });
+          }
+        }
+        if (btnItems.length > 0) {
+          result.push(...btnItems);
+        }
+        continue;
+      }
+
+      result.push({
+        label: this.itemLabel(item),
+        icon,
         enabled: item.enable !== false,
-        submenu: item.children ? this.buildNativeMenuTemplate(item.children) : undefined,
-        click: item.menu_id ? () => {
-          this.onClick?.(item.menu_id!);
-        } : undefined,
+        submenu: item.children
+          ? await this.buildNativeMenuTemplate(item.children)
+          : undefined,
+        click: item.menu_id
+          ? () => {
+            this.onClick?.(item.menu_id!);
+          }
+          : undefined,
         accelerator: item.hotkey,
-      };
-    });
+      });
+    }
+
+    return result;
   }
 
   /** Collect all distinct style paths from items and load their XML from the skin pack. */
@@ -112,11 +241,12 @@ export default class AppMenu extends EventTarget {
 
   async show() {
     this.closed = false;
+    this.loadedIcons = {}; // Clear icon cache to support skin updates
 
-    const isGnome = isGnomeDesktop();
+    const isGnome = useGnomeNativeMenu();
     console.log(`[menu.show] isGnome=${isGnome}, items=${this.items.length}`);
     if (isGnome) {
-      const template = this.buildNativeMenuTemplate(this.items);
+      const template = await this.buildNativeMenuTemplate(this.items);
       console.log(`[menu.show] built native template, ${template.length} entries`);
       const nativeMenu = Menu.buildFromTemplate(template);
 
@@ -146,7 +276,7 @@ export default class AppMenu extends EventTarget {
       this.submenuWindow = null;
     }
 
-    const isGnome = isGnomeDesktop();
+    const isGnome = useGnomeNativeMenu();
     if (isGnome) {
       this.dispatchEvent(new Event("close"));
       return;
@@ -167,12 +297,14 @@ export default class AppMenu extends EventTarget {
       patchById(this.items, patch);
     }
 
-    const isGnome = isGnomeDesktop();
+    const isGnome = useGnomeNativeMenu();
     if (isGnome) {
-
-      const template = this.buildNativeMenuTemplate(this.items);
-      const nativeMenu = Menu.buildFromTemplate(template);
-      setTrayMenu(nativeMenu);
+      this.loadedIcons = {}; // Clear cache for update
+      (async () => {
+        const template = await this.buildNativeMenuTemplate(this.items);
+        const nativeMenu = Menu.buildFromTemplate(template);
+        setTrayMenu(nativeMenu);
+      })();
       return;
     }
 

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -1,11 +1,18 @@
 import os from "node:os";
 
-import { Menu, nativeImage, NativeImage, Tray } from "electron";
+import { Menu, MenuItem, nativeImage, NativeImage, Tray } from "electron";
 
 import { mainWindow } from "./window";
 import { kvGet } from "./kv";
 
-export function isGnomeDesktop(): boolean {
+export function useGnomeNativeMenu(): boolean {
+  return isGnomeDesktop() && kvGet("tray.clickBehavior") === "with-native-menu-gnome";
+}
+export function useNativeMenu(): boolean {
+  return kvGet("tray.clickBehavior") === "with-native-menu";
+}
+
+function isGnomeDesktop(): boolean {
   return process.env.XDG_CURRENT_DESKTOP?.toLowerCase().includes("gnome") === true;
 }
 
@@ -73,25 +80,50 @@ export function install() {
     trayIcon.setContextMenu(menu);
   }
 
-  // 在 GNOME 上，在安装时设置一个占位符上下文菜单。
+  // 在 GNOME 兼容模式下，在安装时设置一个占位符上下文菜单。
   // 建立 AppIndicator D-Bus 菜单注册，以便后续的 setContextMenu() 更新能被 GNOME Shell 捕获。
-  if (isGnomeDesktop() && !menu) {
+  if (useGnomeNativeMenu() && !menu) {
+    console.log("[tray] GNOME: installing placeholder menu!!");
     const placeholder = Menu.buildFromTemplate([
       { label: "加载中...", enabled: false },
     ]);
     trayIcon.setContextMenu(placeholder);
     console.log("[tray] GNOME: set placeholder context menu at install time");
+
+    // 由于设置了上下文菜单，Linux 上的 'click' 事件将不再触发。
+    // 在此手动向渲染进程发送一个点击事件，以触发布建真实菜单的逻辑。
+    if (mainWindow) {
+      console.log("[tray] GNOME: triggering initial menu sync");
+      mainWindow.webContents.send("channel.call", "trayicon.onrightclick");
+    }
+  }
+  if (useNativeMenu() && !menu) {
+    const nativeMenu = new Menu();
+    nativeMenu.append(
+      new MenuItem({
+        label: "显示菜单",
+        click: () => {
+          mainWindow?.webContents.send(
+            "channel.call",
+            "trayicon.onrightclick"
+          );
+        },
+      })
+    );
+    setMenu(nativeMenu);
   }
 
   trayIcon.on("click", () => {
     if (!mainWindow) return;
     // Linux can only receives click, so a different behavior is used
     // The `onclick` will be send when main window is invisible, and `onrightclick` will be send when main window is visible
+    // We only send rightclick here if is Linux, the main window is visible, and the user has not set the click behavior to "with-native-menu" or "with-native-menu-gnome"
     const eventName =
       os.platform() !== "linux" ||
         (kvGet("tray.clickBehavior") !== "always-show-menu" &&
           !mainWindow.isVisible()) ||
-        kvGet("tray.clickBehavior") === "with-native-menu"
+        kvGet("tray.clickBehavior") === "with-native-menu" ||
+        kvGet("tray.clickBehavior") === "with-native-menu-gnome"
         ? "trayicon.onclick"
         : "trayicon.onrightclick";
     mainWindow.webContents.send("channel.call", eventName);

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -5,6 +5,10 @@ import { Menu, nativeImage, NativeImage, Tray } from "electron";
 import { mainWindow } from "./window";
 import { kvGet } from "./kv";
 
+export function isGnomeDesktop(): boolean {
+  return process.env.XDG_CURRENT_DESKTOP?.toLowerCase().includes("gnome") === true;
+}
+
 let icon: NativeImage | null = null;
 let tooltip: string | null = null;
 let menu: Menu | null = null;
@@ -68,21 +72,29 @@ export function install() {
   if (menu) {
     trayIcon.setContextMenu(menu);
   }
+
+  // 在 GNOME 上，在安装时设置一个占位符上下文菜单。
+  // 建立 AppIndicator D-Bus 菜单注册，以便后续的 setContextMenu() 更新能被 GNOME Shell 捕获。
+  if (isGnomeDesktop() && !menu) {
+    const placeholder = Menu.buildFromTemplate([
+      { label: "加载中...", enabled: false },
+    ]);
+    trayIcon.setContextMenu(placeholder);
+    console.log("[tray] GNOME: set placeholder context menu at install time");
+  }
+
   trayIcon.on("click", () => {
     if (!mainWindow) return;
     // Linux can only receives click, so a different behavior is used
     // The `onclick` will be send when main window is invisible, and `onrightclick` will be send when main window is visible
-    mainWindow.webContents.send(
-      "channel.call",
-      // We only send rightclick here if is Linux, the main window is visible, and the user has not set the click behavior to "with-native-menu",
-      // or, on Linux, if the user has set the click behavior to "always-show-menu", in which case we always send rightclick to show the menu
+    const eventName =
       os.platform() !== "linux" ||
         (kvGet("tray.clickBehavior") !== "always-show-menu" &&
           !mainWindow.isVisible()) ||
         kvGet("tray.clickBehavior") === "with-native-menu"
         ? "trayicon.onclick"
-        : "trayicon.onrightclick"
-    );
+        : "trayicon.onrightclick";
+    mainWindow.webContents.send("channel.call", eventName);
   });
   trayIcon.on("right-click", () => {
     if (!mainWindow) return;

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
         "@open-orpheus/database",
         "@open-orpheus/window",
         "@open-orpheus/ui",
+        "@resvg/resvg-js",
       ],
     },
   },


### PR DESCRIPTION
尝试修复Gnome shell上托盘菜单的问题。
本机编译测试已通过。
但可能与“使用原生菜单” 选项冲突