### PR TITLE
修复主界面关闭后播放界面特效渲染卡死

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -332,7 +332,6 @@ app.on("before-quit", () => {
 app.on("second-instance", () => {
   const [win] = BrowserWindow.getAllWindows();
   if (win) {
-    if (win.isMinimized()) win.restore();
-    win.focus();
+    win.webContents.send("channel.call", "ipc.onipcmessagerecived", 1, null);
   }
 });

--- a/src/main/calls/winhelper.ts
+++ b/src/main/calls/winhelper.ts
@@ -47,10 +47,10 @@ registerCallHandler<[], [boolean]>("winhelper.isWindowFullScreen", () => [
 
 registerCallHandler<
   ["minimize" | "maximize" | "restore" | "hide" | "show"],
-  void
+  [boolean]
 >("winhelper.showWindow", (event, show) => {
   const wnd = BrowserWindow.fromWebContents(event.sender);
-  if (!wnd) return;
+  if (!wnd) return [false];
 
   switch (show) {
     case "minimize":
@@ -69,6 +69,8 @@ registerCallHandler<
       wnd.show();
       break;
   }
+
+  return [true];
 });
 
 registerCallHandler<[string], void>(
@@ -407,9 +409,7 @@ registerCallHandler<MenuRequest, void>(
         return;
       }
       if (itemId === "openOrpheus.showMainWindow") {
-        if (!mainWindow) return;
-        mainWindow.show();
-        mainWindow.focus();
+        event.sender.send("channel.call", "trayicon.onclick");
         return;
       }
       event.sender.send("channel.call", "winhelper.onmenuclick", itemId, id);


### PR DESCRIPTION
close #71 
卡住的原因是 Promise 卡住了
```js
showWindow(e, t) {
    return function*() {
        // 1. 呼叫主进程显示窗口，【挂起当前协程，等待主进程返回结果】
        yield call(WindowHelper.show); 
        // 2. 主进程返回成功后，更新前端状态，通知 WASM 引擎恢复动画
        yield put({ type: "onUpdate", payload: { isWindowHide: false } }); 
    }()
}
```
卡在第一个yield了，没能执行到赋值 isWindowHide: false ，导致播放器还以为是 true ，就不渲染了
整体上是给 winhelper 的监听加个返回值，让 Promise 正常进行
修改 openOrpheus.showMainWindow 事件直接复用了网易云前端左键单击托盘的 channel call 进而正常激活动画
修改 second-instance 为一个 channel call 复用了网易云打开时双击快捷方式的 channel call 直接唤醒后台的程序到前台
onipcmessagerecived 莫名其妙的 1 是什么：
```js
const n = new Map([
    [0, "exitmessage"],
    [1, "foregroundpreinstance"],
    [2, "playlocalmusic"],
    [3, "webmessage"],
    [6, "recognizemusic"]
])
```
已在 kde 和 hyprland 测试