### PR TITLE
修复非会员选择VIP歌曲试听引导页无限加载

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -93,7 +93,6 @@ const createWindow = () => {
     frame: false,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
-      nodeIntegrationInSubFrames: true,
     },
   });
 
@@ -160,6 +159,18 @@ const createWindow = () => {
     if (quitting) return;
     mainWindow.webContents.send("channel.call", "winhelper.onclose");
     e.preventDefault();
+  });
+
+  // Some page need window.channel exists but do not really use
+  mainWindow.webContents.on("frame-created", (event, details) => {
+    const frame = details.frame;
+    if (!frame) return;
+    frame.on("dom-ready", () => {
+      if (frame.isDestroyed()) return;
+      const url = new URL(frame.url);
+      if (url.protocol === "https:" || url.hostname.endsWith("music.163.com"))
+        frame.executeJavaScript("window.channel = window.channel ?? {};");
+    });
   });
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,6 +93,7 @@ const createWindow = () => {
     frame: false,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
+      nodeIntegrationInSubFrames: true,
     },
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -160,18 +160,6 @@ const createWindow = () => {
     mainWindow.webContents.send("channel.call", "winhelper.onclose");
     e.preventDefault();
   });
-
-  // Some page need window.channel exists but do not really use
-  mainWindow.webContents.on("frame-created", (event, details) => {
-    const frame = details.frame;
-    if (!frame) return;
-    frame.on("dom-ready", () => {
-      if (frame.isDestroyed()) return;
-      const url = new URL(frame.url);
-      if (url.protocol === "https:" || url.hostname.endsWith("music.163.com"))
-        frame.executeJavaScript("window.channel = window.channel ?? {};");
-    });
-  });
 };
 
 // This method will be called when Electron has finished
@@ -220,6 +208,27 @@ app.on("ready", async () => {
       }
       await packManager.loadWebPack(); // Simply try loading again after download, it will throw if the package is still invalid
     }
+
+    // Some pages need window.channel, but do not really use
+    app.on("web-contents-created", (e, wc) => {
+      if (wc.session !== session.defaultSession) return; // Only enable for default session
+
+      wc.on("frame-created", (event, details) => {
+        const frame = details.frame;
+        if (!frame) return;
+
+        frame.on("dom-ready", () => {
+          if (frame.isDestroyed()) return;
+          const url = new URL(frame.url);
+          // We want only secure, trusted pages
+          if (
+            url.protocol === "https:" ||
+            url.hostname.endsWith("music.163.com")
+          )
+            frame.executeJavaScript("window.channel = window.channel ?? {};");
+        });
+      });
+    });
 
     // Initialize schemes and get registrars
     const [registerOrpheusScheme, registerAudioScheme] = await Promise.all([

--- a/src/main/calls/winhelper.ts
+++ b/src/main/calls/winhelper.ts
@@ -252,7 +252,6 @@ registerCallHandler<[string, WindowDimensions, WindowAttributes], [boolean]>(
       frame: !attributes.spec_window, // is this correct?
       webPreferences: {
         preload: path.join(__dirname, "preload.js"),
-        nodeIntegrationInSubFrames: true,
       },
     });
     wnd.loadURL(url);

--- a/src/main/calls/winhelper.ts
+++ b/src/main/calls/winhelper.ts
@@ -252,6 +252,7 @@ registerCallHandler<[string, WindowDimensions, WindowAttributes], [boolean]>(
       frame: !attributes.spec_window, // is this correct?
       webPreferences: {
         preload: path.join(__dirname, "preload.js"),
+        nodeIntegrationInSubFrames: true,
       },
     });
     wnd.loadURL(url);


### PR DESCRIPTION
## 现象
非会员在播放列表选择一首 VIP 试听歌曲（不能在日推页测试，日推对非会员开放全曲试听）播放时除了只能播放 30s 之外还应该有一个引导开通黑胶的页面，如图
<img width="1071" height="765" alt="image" src="https://github.com/user-attachments/assets/779b0d52-034b-4ae9-bce4-8cac721ef735" />

> 该页面每天只会显示有限次，且只会对非会员且无看广告免费听用户展示，具体是否显示由服务端云控

然而当前这个页面被唤起后会无限加载，不显示（如图）

<img width="1088" height="772" alt="image" src="https://github.com/user-attachments/assets/2c286fc5-a2ed-49ce-bed7-37fe87fea434" />

## 原因
这个页面在一个客户端内 iframe 展示，域名为 `music.163.com` 
[这里放个样例](https://music.163.com/st/vipcashier-v4/mini/?messageSrc=im&channel=netease&type=try&songId=2022523039&resourceType=try)
这个页面 JS 有一个检测，检测这个页面是否在客户端内打开，如果是则会发一个信号（`window.top.postMessage(JSON.stringify({ type: "jsbridge", type: "cashier:pageloaded" }), "orpheus://orpheus")`）给客户端表示页面加载完毕，可以把 loading 撤下去了
其检测方式是检测iframe内 `window.channel` 是否存在
目前 preload.js 只会在主页跑，并不会穿透到 iframe ，导致检测页无法得知其为客户端，就发不出去这个信号，表现为无限 loading

## 目前的解决方案
给需要新建窗口的地方加一个参数，
new BrowserWindow([options])
nodeIntegrationInSubFrames boolean (可选项)(实验性)，是否允许在子页面(iframe)或子窗口(child window)中集成Node.js； 预先加载的脚本会被注入到每一个iframe，你可以用 process.isMainFrame 来判断当前是否处于主框架（main frame）中。
（引用自 Electron 文档，https://www.electronjs.org/zh/docs/latest/api/browser-window#new-browserwindowoptions ）
该修复方式或许还能解决一些 iframe html 内调用客户端的原始能力产生的问题（比如页面调个channel.call现在也可以了）