### PR TITLE
允许启用 Electron 默认菜单

### DIFF
--- a/gui/src/routes/Debug.svelte
+++ b/gui/src/routes/Debug.svelte
@@ -11,6 +11,9 @@
 <Button class="mt-4" onclick={() => api.gpu.openInfo()}
   >打开 chrome://gpu</Button
 >
+<Button class="mt-4" onclick={() => api.menu.enableDefaultMenu()}
+  >启用 Electron 默认菜单</Button
+>
 <p class="mt-2 text-sm text-gray-400">
   Node.JS {api.versions.node} | Chromium {api.versions.chrome} | Electron {api
     .versions.electron}

--- a/src/bridge/contracts/manage-api.ts
+++ b/src/bridge/contracts/manage-api.ts
@@ -20,4 +20,7 @@ export interface ManageContract {
   gpu: {
     openInfo(): Promise<void>;
   };
+  menu: {
+    enableDefaultMenu(): Promise<void>;
+  };
 }

--- a/src/main/windows/manage.ts
+++ b/src/main/windows/manage.ts
@@ -1,7 +1,8 @@
+import os from "node:os";
 import path, { resolve } from "node:path";
 import { readdir, stat, rm } from "node:fs/promises";
 
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, Menu } from "electron";
 import packManager from "../pack";
 import WebPack from "../packs/WebPack";
 import { wasm as wasmDir } from "../folders";
@@ -115,6 +116,24 @@ export default function showManageWindow() {
             partition: "open-orpheus",
           },
         }).loadURL("chrome://gpu");
+      },
+    },
+
+    menu: {
+      enableDefaultMenu: async () => {
+        const macAppMenu: Electron.MenuItemConstructorOptions = {
+          role: "appMenu",
+        };
+        const template: Electron.MenuItemConstructorOptions[] = [
+          ...(os.platform() === "darwin" ? [macAppMenu] : []),
+          { role: "fileMenu" },
+          { role: "editMenu" },
+          { role: "viewMenu" },
+          { role: "windowMenu" },
+        ];
+
+        const menu = Menu.buildFromTemplate(template);
+        Menu.setApplicationMenu(menu);
       },
     },
   });


### PR DESCRIPTION
这将重新允许用户在已打包程序中通过菜单、快捷键进行打开 DevTools 等操作