### PR TITLE
修复 AudioStreamer

### DIFF
--- a/src/main/audio/streamer.ts
+++ b/src/main/audio/streamer.ts
@@ -1,23 +1,79 @@
 import type { IncomingHttpHeaders, IncomingMessage } from "node:http";
-import { Readable } from "node:stream";
-import { stat } from "node:fs/promises";
 import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { Readable } from "node:stream";
 
-import mime from "mime";
 import Emittery from "emittery";
+import mime from "mime";
 
 import type { AudioPlayInfo } from "../../preload/Player";
 import client from "../request";
+import { sleep } from "../../util";
 
+// #region Constants
 const CHUNK_SIZE = 2 * 1024 * 1024; // 2 MB chunk limit to prevent lock starvation
+const CONSUMER_CHUNK_SIZE = 256 * 1024;
+const MAX_FETCH_ATTEMPTS = 3;
+const BASE_FETCH_RETRY_DELAY_MS = 250;
+const MAX_FETCH_RETRY_DELAY_MS = 2000;
+// #endregion
 
-// #region Interval helpers
+// #region Types
 type Interval = [start: number, end: number]; // inclusive [start, end]
 
+interface SongBuffer {
+  songId: string;
+  playInfo: AudioPlayInfo;
+  generation: number;
+  url: string;
+  totalSize: number;
+  buffer: Buffer;
+  intervals: Interval[]; // Ranges fully downloaded and written to RAM
+  pendingIntervals: Interval[]; // Exact locks for ranges currently being fetched
+  backgroundFetchInProgress: boolean;
+  contentType: string;
+  fetchFailures: Map<string, FetchFailure>;
+}
+
+interface ChunkWrittenDetail {
+  start: number;
+  end: number;
+}
+
+interface FetchFailure {
+  attempts: number;
+  retryAt: number;
+  error: unknown;
+}
+
+interface OpenedRangeStream {
+  stream: Readable;
+  headers: IncomingHttpHeaders;
+  actualStart: number;
+  statusCode: number;
+}
+
+interface ParsedRange {
+  start: number;
+  end?: number;
+}
+
+export type AudioStreamerEvents = {
+  progress: { playInfo: AudioPlayInfo; buffer: SongBuffer; progress: number };
+  complete: { playInfo: AudioPlayInfo; buffer: SongBuffer };
+
+  chunkwritten: ChunkWrittenDetail;
+  chunkerror: unknown;
+  bufferchange: undefined;
+};
+// #endregion
+
+// #region Interval helpers
 class IntervalMath {
   static merge(intervals: Interval[], added: Interval): void {
     intervals.push(added);
     intervals.sort((a, b) => a[0] - b[0]);
+
     let write = 0;
     for (let i = 0; i < intervals.length; i++) {
       if (write > 0 && intervals[i][0] <= intervals[write - 1][1] + 1) {
@@ -32,37 +88,32 @@ class IntervalMath {
     intervals.length = write;
   }
 
-  static remove(
-    intervals: Interval[],
-    [removeStart, removeEnd]: Interval
-  ): void {
-    const result: Interval[] = [];
-    for (const [s, e] of intervals) {
-      if (e < removeStart || s > removeEnd) {
-        result.push([s, e]); // No overlap
-      } else {
-        // Overlap: carve out the removed portion
-        if (s < removeStart) result.push([s, removeStart - 1]);
-        if (e > removeEnd) result.push([removeEnd + 1, e]);
-      }
-    }
-    intervals.length = 0;
-    intervals.push(...result);
+  static addPending(intervals: Interval[], added: Interval): void {
+    intervals.push(added);
+    intervals.sort((a, b) => a[0] - b[0]);
+  }
+
+  static removePending(intervals: Interval[], removed: Interval): void {
+    const index = intervals.findIndex(
+      ([s, e]) => s === removed[0] && e === removed[1]
+    );
+    if (index !== -1) intervals.splice(index, 1);
   }
 
   static missing(have: Interval[], start: number, end: number): Interval[] {
     const missing: Interval[] = [];
     let cursor = start;
+
     for (const [s, e] of have) {
       if (s > cursor) missing.push([cursor, Math.min(s - 1, end)]);
       cursor = Math.max(cursor, e + 1);
       if (cursor > end) break;
     }
+
     if (cursor <= end) missing.push([cursor, end]);
     return missing;
   }
 
-  /** Union & Subtract: Requested - (Have + Pending) */
   static trulyMissing(
     requested: Interval,
     have: Interval[],
@@ -70,9 +121,11 @@ class IntervalMath {
   ): Interval[] {
     const missingFromHave = this.missing(have, requested[0], requested[1]);
     const trulyMissing: Interval[] = [];
+
     for (const [mStart, mEnd] of missingFromHave) {
       trulyMissing.push(...this.missing(pending, mStart, mEnd));
     }
+
     return trulyMissing;
   }
 
@@ -82,36 +135,213 @@ class IntervalMath {
 }
 // #endregion
 
-// #region Per-song buffer state
-interface SongBuffer {
-  songId: string;
-  url: string;
-  totalSize: number;
-  buffer: Buffer;
-  intervals: Interval[]; // Ranges fully downloaded and written to RAM
-  pendingIntervals: Interval[]; // Lock Array: Ranges currently being fetched by an active HTTP request
-  backgroundFetchInProgress: boolean;
-  contentType: string;
+// #region Pure helpers
+function getHeaderValue(v: string | string[] | undefined): string | undefined {
+  return Array.isArray(v) ? v[0] : v;
 }
 
-interface ChunkWrittenDetail {
-  start: number;
-  end: number;
+function parseSizeFromHeaders(headers: IncomingHttpHeaders): {
+  totalSize: number;
+  contentType: string;
+} {
+  const contentType = getHeaderValue(headers["content-type"]) ?? "audio/mpeg";
+  const contentRange = getHeaderValue(headers["content-range"]);
+
+  if (contentRange) {
+    const match = contentRange.match(/\/(\d+)/);
+    if (match) return { totalSize: Number(match[1]), contentType };
+  }
+
+  const contentLength = getHeaderValue(headers["content-length"]);
+  return {
+    totalSize: contentLength ? Number(contentLength) : 0,
+    contentType,
+  };
+}
+
+function parseRangeHeader(rangeHeader: string | null): ParsedRange | null {
+  if (!rangeHeader) return { start: 0 };
+
+  const match = rangeHeader.match(/bytes=(\d+)-(\d*)/);
+  if (!match) return null;
+
+  return {
+    start: Number(match[1]),
+    end: match[2] ? Number(match[2]) : undefined,
+  };
+}
+
+function getRangeKey(start: number, end: number): string {
+  return `${start}-${end}`;
+}
+
+function getFetchDelay(attempts: number): number {
+  return Math.min(
+    BASE_FETCH_RETRY_DELAY_MS * 2 ** Math.max(0, attempts - 1),
+    MAX_FETCH_RETRY_DELAY_MS
+  );
+}
+
+function getChunkEnd(start: number, end: number): number {
+  return Math.min(end, start + CHUNK_SIZE - 1);
+}
+
+function getMissingChunks(
+  sb: SongBuffer,
+  start: number,
+  end: number
+): Interval[] {
+  return IntervalMath.trulyMissing(
+    [start, end],
+    sb.intervals,
+    sb.pendingIntervals
+  ).map(([mStart, mEnd]) => [mStart, getChunkEnd(mStart, mEnd)]);
+}
+
+function getFirstMissingChunk(
+  sb: SongBuffer,
+  start: number,
+  end: number
+): Interval | null {
+  return getMissingChunks(sb, start, end)[0] ?? null;
+}
+
+function getAvailableEnd(sb: SongBuffer, cursor: number): number {
+  for (const [s, e] of sb.intervals) {
+    if (cursor >= s && cursor <= e) return e;
+  }
+  return -1;
+}
+
+function hasRange(sb: SongBuffer, start: number, end: number): boolean {
+  return getAvailableEnd(sb, start) >= end;
+}
+
+function isPending(sb: SongBuffer, cursor: number): boolean {
+  return sb.pendingIntervals.some(([s, e]) => cursor >= s && cursor <= e);
+}
+
+function getFetchFailure(
+  sb: SongBuffer,
+  start: number,
+  end: number
+): FetchFailure | undefined {
+  return sb.fetchFailures.get(getRangeKey(start, end));
+}
+
+function registerFetchSuccess(
+  sb: SongBuffer,
+  start: number,
+  end: number
+): void {
+  sb.fetchFailures.delete(getRangeKey(start, end));
+}
+
+function registerFetchFailure(
+  sb: SongBuffer,
+  start: number,
+  end: number,
+  error: unknown
+): void {
+  const key = getRangeKey(start, end);
+  const attempts = (sb.fetchFailures.get(key)?.attempts ?? 0) + 1;
+
+  sb.fetchFailures.set(key, {
+    attempts,
+    retryAt: Date.now() + getFetchDelay(attempts),
+    error,
+  });
+}
+
+function canFetchRange(sb: SongBuffer, start: number, end: number): boolean {
+  const failure = getFetchFailure(sb, start, end);
+  return !failure || failure.attempts < MAX_FETCH_ATTEMPTS;
+}
+
+function getRetryDelay(sb: SongBuffer, start: number, end: number): number {
+  const failure = getFetchFailure(sb, start, end);
+  if (!failure) return 0;
+  return Math.max(0, failure.retryAt - Date.now());
+}
+
+function createCachedSlice(
+  sb: SongBuffer,
+  start: number,
+  end: number
+): Uint8Array {
+  return new Uint8Array(
+    sb.buffer.buffer,
+    sb.buffer.byteOffset + start,
+    end - start + 1
+  );
+}
+
+function createNodeWebStream(nodeStream: ReturnType<typeof createReadStream>) {
+  return new ReadableStream({
+    start(controller) {
+      nodeStream.on("data", (chunk) => controller.enqueue(chunk));
+      nodeStream.on("end", () => controller.close());
+      nodeStream.on("error", (err) => controller.error(err));
+    },
+    cancel() {
+      nodeStream.destroy();
+    },
+  });
 }
 // #endregion
 
-export type AudioStreamerEvents = {
-  progress: { playInfo: AudioPlayInfo; buffer: SongBuffer; progress: number };
-  complete: { playInfo: AudioPlayInfo; buffer: SongBuffer };
+// #region Upstream HTTP helpers
+async function openRangeStream(
+  url: string,
+  start: number,
+  end?: number
+): Promise<OpenedRangeStream> {
+  const rangeValue =
+    end !== undefined ? `bytes=${start}-${end}` : `bytes=${start}-`;
 
-  chunkwritten: ChunkWrittenDetail;
-  chunkerror: unknown;
-};
+  const stream = client.stream(url, {
+    headers: { Range: rangeValue },
+    throwHttpErrors: false,
+  }) as unknown as Readable;
+
+  const response = await new Promise<IncomingMessage>((resolve, reject) => {
+    stream.once("response", (res: IncomingMessage) => resolve(res));
+    stream.once("error", reject);
+  });
+
+  if (response.statusCode && response.statusCode >= 400) {
+    stream.destroy();
+    throw new Error(`Upstream HTTP Error: ${response.statusCode}`);
+  }
+
+  let actualStart = start;
+  if (response.statusCode === 206) {
+    const contentRange = response.headers["content-range"];
+    if (typeof contentRange === "string") {
+      const match = contentRange.match(/bytes\s+(\d+)-/i);
+      if (match) actualStart = Number(match[1]);
+    }
+  } else if (response.statusCode === 200) {
+    actualStart = 0;
+  }
+
+  return {
+    stream,
+    headers: response.headers,
+    actualStart,
+    statusCode: response.statusCode ?? 0,
+  };
+}
+// #endregion
 
 export default class AudioStreamer extends Emittery<AudioStreamerEvents> {
+  // #region State
   private songBuffer: SongBuffer | null = null;
   private currentAudioPlayInfo: AudioPlayInfo | null = null;
+  private playInfoGeneration = 0;
+  // #endregion
 
+  // #region Accessors
   get buffer() {
     return this.songBuffer;
   }
@@ -119,182 +349,304 @@ export default class AudioStreamer extends Emittery<AudioStreamerEvents> {
   get audioPlayInfo() {
     return this.currentAudioPlayInfo;
   }
+  // #endregion
 
-  constructor() {
-    super();
-  }
-
+  // #region Playback lifecycle
   setPlayInfo(playInfo: AudioPlayInfo | null): void {
+    this.playInfoGeneration++;
     this.currentAudioPlayInfo = playInfo;
+
+    if (this.songBuffer) {
+      this.songBuffer = null;
+      this.notifyFetchError(new Error("Audio play info changed"));
+      this.notifyBufferChanged();
+    }
   }
 
-  private onProgress(progress: number): void {
-    if (!this.currentAudioPlayInfo || !this.songBuffer) return;
-    this.emit("progress", {
-      playInfo: this.currentAudioPlayInfo,
-      buffer: this.songBuffer,
+  private isCurrentGeneration(generation: number, songId: string): boolean {
+    return (
+      this.playInfoGeneration === generation &&
+      this.currentAudioPlayInfo?.songId === songId
+    );
+  }
+  // #endregion
+
+  // #region Event helpers
+  private notifyFetchError(error: unknown): void {
+    void this.emit("chunkerror", error);
+  }
+
+  private notifyBufferChanged(): void {
+    void this.emit("bufferchange");
+  }
+
+  private onProgress(sb: SongBuffer, progress: number): void {
+    if (this.songBuffer !== sb) return;
+    void this.emit("progress", {
+      playInfo: sb.playInfo,
+      buffer: sb,
       progress,
     });
   }
 
-  private onComplete(): void {
-    if (!this.songBuffer || !this.currentAudioPlayInfo) return;
-    this.emit("complete", {
-      playInfo: this.currentAudioPlayInfo,
-      buffer: this.songBuffer,
+  private onComplete(sb: SongBuffer): void {
+    if (this.songBuffer !== sb) return;
+    void this.emit("complete", {
+      playInfo: sb.playInfo,
+      buffer: sb,
     });
   }
 
-  private parseSizeFromHeaders(headers: IncomingHttpHeaders): {
-    totalSize: number;
-    contentType: string;
-  } {
-    const getHeader = (v: string | string[] | undefined) =>
-      Array.isArray(v) ? v[0] : v;
+  private waitForData(
+    sb: SongBuffer,
+    signal: AbortSignal,
+    timeoutMs?: number
+  ): Promise<void> {
+    if (this.songBuffer !== sb) return Promise.resolve();
+    if (timeoutMs !== undefined && timeoutMs <= 0) return Promise.resolve();
 
-    const contentType = getHeader(headers["content-type"]) ?? "audio/mpeg";
-    const cr = getHeader(headers["content-range"]);
-    if (cr) {
-      const match = cr.match(/\/(\d+)/);
-      if (match) return { totalSize: Number(match[1]), contentType };
-    }
-    const cl = getHeader(headers["content-length"]);
-    return { totalSize: cl ? Number(cl) : 0, contentType };
-  }
+    return new Promise<void>((resolve, reject) => {
+      let retryTimer: NodeJS.Timeout | null = null;
 
-  private async openRangeStream(
-    url: string,
-    start: number,
-    end?: number
-  ): Promise<{
-    stream: Readable;
-    headers: IncomingHttpHeaders;
-    actualStart: number;
-  }> {
-    const rangeValue =
-      end !== undefined ? `bytes=${start}-${end}` : `bytes=${start}-`;
+      const cleanup = () => {
+        if (retryTimer) clearTimeout(retryTimer);
+        this.off("chunkwritten", onWakeup);
+        this.off("chunkerror", onWakeup);
+        this.off("bufferchange", onWakeup);
+        signal.removeEventListener("abort", onAbort);
+      };
 
-    const stream = client.stream(url, {
-      headers: { Range: rangeValue },
-      throwHttpErrors: false,
-    }) as unknown as Readable;
+      const onWakeup = () => {
+        cleanup();
+        resolve();
+      };
 
-    const response = await new Promise<IncomingMessage>((resolve, reject) => {
-      stream.once("response", (res: IncomingMessage) => resolve(res));
-      stream.once("error", reject);
+      const onAbort = () => {
+        cleanup();
+        reject(new Error("Stream cancelled by browser"));
+      };
+
+      this.on("chunkwritten", onWakeup);
+      this.on("chunkerror", onWakeup);
+      this.on("bufferchange", onWakeup);
+      signal.addEventListener("abort", onAbort, { once: true });
+
+      if (timeoutMs !== undefined) retryTimer = setTimeout(onWakeup, timeoutMs);
+      if (signal.aborted) onAbort();
+      if (this.songBuffer !== sb) onWakeup();
     });
-
-    if (response.statusCode && response.statusCode >= 400) {
-      stream.destroy();
-      throw new Error(`Upstream HTTP Error: ${response.statusCode}`);
-    }
-
-    let actualStart = start;
-    if (response.statusCode === 206) {
-      const cr = response.headers["content-range"];
-      if (typeof cr === "string") {
-        const match = cr.match(/bytes\s+(\d+)-/i);
-        if (match) actualStart = Number(match[1]);
-      }
-    } else if (response.statusCode === 200) {
-      actualStart = 0;
-    }
-
-    return { stream, headers: response.headers, actualStart };
   }
+  // #endregion
 
+  // #region Buffer lifecycle
   private ensureSongBuffer(
     songId: string,
+    playInfo: AudioPlayInfo,
+    generation: number,
     url: string,
     totalSize: number,
     contentType: string
   ): SongBuffer {
-    if (this.songBuffer?.songId === songId) return this.songBuffer;
+    if (
+      this.songBuffer?.songId === songId &&
+      this.songBuffer.generation === generation
+    )
+      return this.songBuffer;
 
     this.songBuffer = {
       songId,
+      playInfo,
+      generation,
       url,
       totalSize,
-      buffer: Buffer.alloc(totalSize),
+      buffer: Buffer.allocUnsafe(totalSize),
       intervals: [],
       pendingIntervals: [],
       backgroundFetchInProgress: false,
       contentType,
+      fetchFailures: new Map(),
     };
+
     return this.songBuffer;
   }
 
-  /**
-   * PRODUCER: Fetches a capped chunk from remote, writes to Buffer, updates Locks, and broadcasts events.
-   */
+  private startMissingFetches(
+    sb: SongBuffer,
+    start: number,
+    end: number,
+    initialStreamData: OpenedRangeStream | null = null
+  ): OpenedRangeStream | null {
+    let reusableStream = initialStreamData;
+
+    for (const [mStart, chunkEnd] of getMissingChunks(sb, start, end)) {
+      if (reusableStream && mStart === start) {
+        void this.fetchAndCache(sb, mStart, chunkEnd, reusableStream);
+        reusableStream = null;
+      } else {
+        void this.fetchAndCache(sb, mStart, chunkEnd);
+      }
+    }
+
+    return reusableStream;
+  }
+  // #endregion
+
+  // #region Producers
   private async fetchAndCache(
     sb: SongBuffer,
     start: number,
     end: number,
-    preOpenedStream?: { stream: Readable; actualStart: number }
-  ): Promise<void> {
-    // 1. Acquire the lock for this specific chunk
-    IntervalMath.merge(sb.pendingIntervals, [start, end]);
+    preOpenedStream?: OpenedRangeStream
+  ): Promise<boolean> {
+    if (this.songBuffer !== sb) return false;
+    if (!canFetchRange(sb, start, end)) return false;
+    if (getRetryDelay(sb, start, end) > 0) return false;
+
+    IntervalMath.addPending(sb.pendingIntervals, [start, end]);
+    let wroteBytes = false;
 
     try {
-      const { stream, actualStart } =
-        preOpenedStream ?? (await this.openRangeStream(sb.url, start, end));
+      const { stream, actualStart, statusCode } =
+        preOpenedStream ?? (await openRangeStream(sb.url, start, end));
+
+      if (this.songBuffer !== sb) {
+        stream.destroy();
+        return false;
+      }
+
+      if (statusCode === 200 && start > 0) {
+        stream.destroy();
+        throw new Error("Upstream ignored range request for non-zero start");
+      }
+
+      if (statusCode === 206 && actualStart !== start) {
+        stream.destroy();
+        throw new Error(
+          `Unexpected upstream content range start: ${actualStart}, expected ${start}`
+        );
+      }
+
       let offset = actualStart;
 
       for await (const value of stream) {
         if (this.songBuffer !== sb) {
           stream.destroy();
-          return;
+          return false;
         }
 
-        const chunk = Buffer.isBuffer(value)
-          ? value
-          : Buffer.from(value as Uint8Array);
-        if (offset >= sb.totalSize) break;
+        const chunk = Buffer.isBuffer(value) ? value : (value as Uint8Array);
+        if (offset > end || offset >= sb.totalSize) {
+          stream.destroy();
+          break;
+        }
 
-        const writableLength = Math.min(chunk.length, sb.totalSize - offset);
-        if (writableLength <= 0) break;
+        const writableLength = Math.min(
+          chunk.byteLength,
+          end - offset + 1,
+          sb.totalSize - offset
+        );
+        if (writableLength <= 0) {
+          stream.destroy();
+          break;
+        }
 
-        // Write directly to the persistent RAM cache
-        chunk.copy(sb.buffer, offset, 0, writableLength);
+        sb.buffer.set(chunk.subarray(0, writableLength), offset);
+        wroteBytes = true;
 
         const chunkStart = offset;
         const chunkEnd = offset + writableLength - 1;
 
-        // 2. Mark bytes as successfully acquired
         IntervalMath.merge(sb.intervals, [chunkStart, chunkEnd]);
         offset += writableLength;
 
-        // 3. Broadcast to sleeping consumers
-        this.emit("chunkwritten", { start: chunkStart, end: chunkEnd });
-
+        void this.emit("chunkwritten", { start: chunkStart, end: chunkEnd });
         this.onProgress(
+          sb,
           IntervalMath.downloadedBytes(sb.intervals) / sb.totalSize
         );
 
-        // 4. Chunk Limit Break: Prevent massive locks by stopping the download exactly when the chunk ends.
         if (offset > end) {
           stream.destroy();
           break;
         }
       }
 
-      if (IntervalMath.downloadedBytes(sb.intervals) >= sb.totalSize) {
-        this.onComplete();
+      if (this.songBuffer === sb && !hasRange(sb, start, end)) {
+        throw new Error(
+          `Upstream ended before requested range was cached: ${start}-${end}`
+        );
       }
+
+      registerFetchSuccess(sb, start, end);
+
+      if (IntervalMath.downloadedBytes(sb.intervals) >= sb.totalSize) {
+        this.onComplete(sb);
+      }
+
+      return true;
     } catch (e) {
-      // Dispatch error so sleeping consumers wake up and retry
-      this.emit("chunkerror", e);
+      registerFetchFailure(sb, start, end, e);
+      this.notifyFetchError(e);
+      return false;
     } finally {
-      // 5. Release Lock: Cleanup bounds (written bytes are already safely in sb.intervals)
-      IntervalMath.remove(sb.pendingIntervals, [start, end]);
+      IntervalMath.removePending(sb.pendingIntervals, [start, end]);
+      if (!wroteBytes) this.notifyBufferChanged();
     }
   }
 
-  /**
-   * CONSUMER: A Web ReadableStream that perfectly feeds the browser requests.
-   * Reads from RAM, dynamically fetching the next 2MB chunk if missing.
-   */
+  private async fetchNextBackgroundChunk(sb: SongBuffer): Promise<boolean> {
+    const target = getFirstMissingChunk(sb, 0, sb.totalSize - 1);
+    if (!target) return false;
+
+    const [start, end] = target;
+    const success = await this.fetchAndCache(sb, start, end);
+    if (success) return true;
+    if (this.songBuffer !== sb) return false;
+
+    const failure = getFetchFailure(sb, start, end);
+    if (failure?.attempts && failure.attempts >= MAX_FETCH_ATTEMPTS) {
+      return false;
+    }
+
+    const retryDelay = getRetryDelay(sb, start, end);
+    if (retryDelay <= 0) return false;
+
+    await sleep(retryDelay);
+    return this.songBuffer === sb;
+  }
+  // #endregion
+
+  // #region Consumers
+  private async waitForMissingConsumerData(
+    sb: SongBuffer,
+    cursor: number,
+    end: number,
+    signal: AbortSignal
+  ): Promise<void> {
+    if (!isPending(sb, cursor)) {
+      const target = getFirstMissingChunk(sb, cursor, end);
+
+      if (target) {
+        const [start, chunkEnd] = target;
+        const failure = getFetchFailure(sb, start, chunkEnd);
+
+        if (failure?.attempts && failure.attempts >= MAX_FETCH_ATTEMPTS) {
+          throw new Error(`Failed to fetch audio range ${start}-${chunkEnd}`);
+        }
+
+        const retryDelay = getRetryDelay(sb, start, chunkEnd);
+        if (retryDelay > 0) {
+          await this.waitForData(sb, signal, retryDelay);
+          return;
+        }
+
+        void this.fetchAndCache(sb, start, chunkEnd);
+      }
+    }
+
+    await this.waitForData(sb, signal);
+  }
+
   private createConsumerStream(
     sb: SongBuffer,
     start: number,
@@ -304,74 +656,34 @@ export default class AudioStreamer extends Emittery<AudioStreamerEvents> {
     const abortController = new AbortController();
 
     return new ReadableStream<Uint8Array>({
-      start: async (controller) => {
+      pull: async (controller) => {
         try {
           while (cursor <= end) {
             if (this.songBuffer !== sb) throw new Error("Song changed");
 
-            // 1. Check if the byte at `cursor` is already available in RAM
-            let availableEnd = -1;
-            for (const [s, e] of sb.intervals) {
-              if (cursor >= s && cursor <= e) {
-                availableEnd = e;
-                break;
-              }
-            }
+            const availableEnd = getAvailableEnd(sb, cursor);
 
             if (availableEnd !== -1) {
-              // WE HAVE DATA: Zero-copy slice directly from the internal ArrayBuffer
-              const chunkEnd = Math.min(availableEnd, end);
-              const slice = new Uint8Array(
-                sb.buffer.buffer,
-                sb.buffer.byteOffset + cursor,
-                chunkEnd - cursor + 1
+              const chunkEnd = Math.min(
+                availableEnd,
+                end,
+                cursor + CONSUMER_CHUNK_SIZE - 1
               );
-              controller.enqueue(slice);
+              controller.enqueue(createCachedSlice(sb, cursor, chunkEnd));
               cursor = chunkEnd + 1;
-            } else {
-              // MISSING DATA: Ensure a Producer is actively fetching it
-              const isPending = sb.pendingIntervals.some(
-                ([s, e]) => cursor >= s && cursor <= e
-              );
 
-              // Pull Mechanism: If no producer is working on this byte, spawn one for the next chunk
-              if (!isPending) {
-                const trulyMissing = IntervalMath.trulyMissing(
-                  [cursor, end],
-                  sb.intervals,
-                  sb.pendingIntervals
-                );
-                if (trulyMissing.length > 0) {
-                  const [mStart, mEnd] = trulyMissing[0];
-                  const chunkEnd = Math.min(mEnd, mStart + CHUNK_SIZE - 1);
-                  void this.fetchAndCache(sb, mStart, chunkEnd);
-                }
-              }
-
-              // Sleep until a Producer broadcasts a chunk
-              await new Promise<void>((resolve, reject) => {
-                const onWakeup = () => {
-                  cleanup();
-                  resolve();
-                };
-
-                const onAbort = () => {
-                  cleanup();
-                  reject(new Error("Stream cancelled by browser"));
-                };
-
-                const cleanup = () => {
-                  this.off("chunkwritten", onWakeup);
-                  this.off("chunkerror", onWakeup);
-                  abortController.signal.removeEventListener("abort", onAbort);
-                };
-
-                this.on("chunkwritten", onWakeup);
-                this.on("chunkerror", onWakeup);
-                abortController.signal.addEventListener("abort", onAbort);
-              });
+              if (cursor > end) controller.close();
+              return;
             }
+
+            await this.waitForMissingConsumerData(
+              sb,
+              cursor,
+              end,
+              abortController.signal
+            );
           }
+
           controller.close();
         } catch (e) {
           try {
@@ -382,31 +694,24 @@ export default class AudioStreamer extends Emittery<AudioStreamerEvents> {
         }
       },
       cancel() {
-        // Triggered immediately when browser aborts a request (e.g., user seeks)
         abortController.abort();
       },
     });
   }
+  // #endregion
 
+  // #region Background preload
   private backgroundFetchFull(sb: SongBuffer): void {
     if (sb.backgroundFetchInProgress) return;
     sb.backgroundFetchInProgress = true;
 
     void (async () => {
       try {
-        while (this.songBuffer === sb) {
-          // Look for gaps anywhere in the file that are NOT currently locked
-          const trulyMissing = IntervalMath.trulyMissing(
-            [0, sb.totalSize - 1],
-            sb.intervals,
-            sb.pendingIntervals
-          );
-          if (trulyMissing.length === 0) break;
-
-          // Aggressively fetch the next missing piece, capped at CHUNK_SIZE
-          const [mStart, mEnd] = trulyMissing[0];
-          const chunkEnd = Math.min(mEnd, mStart + CHUNK_SIZE - 1);
-          await this.fetchAndCache(sb, mStart, chunkEnd);
+        while (
+          this.songBuffer === sb &&
+          (await this.fetchNextBackgroundChunk(sb))
+        ) {
+          // Keep preloading until the buffer is complete, replaced, or blocked.
         }
       } catch {
         // Suppress background errors. Will gracefully resume later.
@@ -415,142 +720,162 @@ export default class AudioStreamer extends Emittery<AudioStreamerEvents> {
       }
     })();
   }
+  // #endregion
 
+  // #region Request handling
   async handleRequest(songId: string, request: Request): Promise<Response> {
-    if (
-      !this.currentAudioPlayInfo ||
-      this.currentAudioPlayInfo.songId !== songId
-    ) {
+    const playInfo = this.currentAudioPlayInfo;
+    const generation = this.playInfoGeneration;
+
+    if (!playInfo || playInfo.songId !== songId) {
       return new Response("No audio play info available for this song", {
         status: 404,
       });
     }
 
-    if (this.currentAudioPlayInfo.type !== 4) {
-      // Native Node Streaming Fallback for Local Files
-      const fileStat = await stat(this.currentAudioPlayInfo.path);
-      const nodeStream = createReadStream(this.currentAudioPlayInfo.path);
-
-      const webStream = new ReadableStream({
-        start(controller) {
-          nodeStream.on("data", (chunk) => controller.enqueue(chunk));
-          nodeStream.on("end", () => controller.close());
-          nodeStream.on("error", (err) => controller.error(err));
-        },
-        cancel() {
-          nodeStream.destroy();
-        },
-      });
-
-      this.onProgress(1);
-      this.onComplete();
-
-      return new Response(webStream, {
-        status: 200,
-        headers: {
-          "Content-Type":
-            mime.getType(this.currentAudioPlayInfo.path) ||
-            "application/octet-stream",
-          "Content-Length": String(fileStat.size),
-        },
-      });
+    if (playInfo.type !== 4) {
+      return this.handleLocalRequest(songId, playInfo, generation);
     }
 
-    const url = this.currentAudioPlayInfo.musicurl;
-    const rangeHeader = request.headers.get("range");
+    return this.handleRemoteRequest(songId, playInfo, generation, request);
+  }
 
-    let start = 0;
-    let end: number | undefined;
+  private async handleLocalRequest(
+    songId: string,
+    playInfo: Extract<AudioPlayInfo, { type: 0 }>,
+    generation: number
+  ): Promise<Response> {
+    const fileStat = await stat(playInfo.path);
 
-    if (rangeHeader) {
-      const match = rangeHeader.match(/bytes=(\d+)-(\d*)/);
-      if (!match) return new Response("Invalid range", { status: 416 });
-      start = Number(match[1]);
-      end = match[2] ? Number(match[2]) : undefined;
+    if (!this.isCurrentGeneration(generation, songId)) {
+      return new Response("Audio play info changed", { status: 404 });
     }
 
-    let sb = this.songBuffer;
-    let initialStreamData: { stream: Readable; actualStart: number } | null =
-      null;
+    const nodeStream = createReadStream(playInfo.path);
 
-    if (!sb || sb.songId !== songId) {
-      try {
-        // Fetch metadata to initialize the Buffer
-        const { stream, headers, actualStart } = await this.openRangeStream(
-          url,
-          start,
-          end
-        );
-        const info = this.parseSizeFromHeaders(headers);
+    return new Response(createNodeWebStream(nodeStream), {
+      status: 200,
+      headers: {
+        "Content-Type":
+          mime.getType(playInfo.path) || "application/octet-stream",
+        "Content-Length": String(fileStat.size),
+      },
+    });
+  }
 
-        if (!info.totalSize)
-          return new Response("Could not determine file size", { status: 502 });
+  private async handleRemoteRequest(
+    songId: string,
+    playInfo: Extract<AudioPlayInfo, { type: 4 }>,
+    generation: number,
+    request: Request
+  ): Promise<Response> {
+    const parsedRange = parseRangeHeader(request.headers.get("range"));
+    if (!parsedRange) return new Response("Invalid range", { status: 416 });
 
-        sb = this.ensureSongBuffer(
-          songId,
-          url,
-          info.totalSize,
-          info.contentType
-        );
-        initialStreamData = { stream, actualStart }; // Kept to save a round-trip
-      } catch {
-        return new Response("Upstream stream initialization error", {
-          status: 502,
-        });
-      }
-    }
+    const sbResult = await this.getRemoteSongBuffer(
+      songId,
+      playInfo,
+      generation,
+      parsedRange
+    );
+    if (sbResult instanceof Response) return sbResult;
 
-    const resolvedEnd = Math.min(end ?? sb.totalSize - 1, sb.totalSize - 1);
+    const { sb, initialStreamData } = sbResult;
+    const resolvedEnd = Math.min(
+      parsedRange.end ?? sb.totalSize - 1,
+      sb.totalSize - 1
+    );
 
-    if (start >= sb.totalSize || start > resolvedEnd) {
+    if (parsedRange.start >= sb.totalSize || parsedRange.start > resolvedEnd) {
+      initialStreamData?.stream.destroy();
       return new Response("Range not satisfiable", {
         status: 416,
         headers: { "Content-Range": `bytes */${sb.totalSize}` },
       });
     }
 
-    // 1. Calculate strictly the bytes we need to fetch from the Network
-    const trulyMissing = IntervalMath.trulyMissing(
-      [start, resolvedEnd],
-      sb.intervals,
-      sb.pendingIntervals
+    const leftoverStream = this.startMissingFetches(
+      sb,
+      parsedRange.start,
+      resolvedEnd,
+      initialStreamData
     );
+    leftoverStream?.stream.destroy();
 
-    // 2. Spawn Network Producers for missing bytes, capped by CHUNK_SIZE
-    for (const [mStart, mEnd] of trulyMissing) {
-      const chunkEnd = Math.min(mEnd, mStart + CHUNK_SIZE - 1);
-
-      if (initialStreamData && mStart === start) {
-        // Reuse the already-open HTTP connection
-        void this.fetchAndCache(sb, mStart, chunkEnd, initialStreamData);
-        initialStreamData = null;
-      } else {
-        void this.fetchAndCache(sb, mStart, chunkEnd);
-      }
-    }
-
-    // 3. Clean up leftover initial stream if it wasn't strictly needed for a missing gap
-    if (initialStreamData) {
-      initialStreamData.stream.destroy();
-    }
-
-    // 4. Fire up background preloading
-    if (rangeHeader) {
+    if (request.headers.has("range")) {
       this.backgroundFetchFull(sb);
     }
 
-    // 5. Connect the Event-Driven Consumer Web Stream to Response
-    return new Response(this.createConsumerStream(sb, start, resolvedEnd), {
-      status: rangeHeader ? 206 : 200,
-      headers: {
-        "Content-Type": sb.contentType,
-        "Content-Length": String(resolvedEnd - start + 1),
-        ...(rangeHeader && {
-          "Content-Range": `bytes ${start}-${resolvedEnd}/${sb.totalSize}`,
-        }),
-        "Accept-Ranges": "bytes",
-        "Cache-Control": "no-store",
-      },
-    });
+    return new Response(
+      this.createConsumerStream(sb, parsedRange.start, resolvedEnd),
+      {
+        status: request.headers.has("range") ? 206 : 200,
+        headers: {
+          "Content-Type": sb.contentType,
+          "Content-Length": String(resolvedEnd - parsedRange.start + 1),
+          ...(request.headers.has("range") && {
+            "Content-Range": `bytes ${parsedRange.start}-${resolvedEnd}/${sb.totalSize}`,
+          }),
+          "Accept-Ranges": "bytes",
+          "Cache-Control": "no-store",
+        },
+      }
+    );
   }
+
+  private async getRemoteSongBuffer(
+    songId: string,
+    playInfo: Extract<AudioPlayInfo, { type: 4 }>,
+    generation: number,
+    range: ParsedRange
+  ): Promise<
+    | {
+        sb: SongBuffer;
+        initialStreamData: OpenedRangeStream | null;
+      }
+    | Response
+  > {
+    const existingBuffer = this.songBuffer;
+    if (
+      existingBuffer?.songId === songId &&
+      existingBuffer.generation === generation
+    ) {
+      return { sb: existingBuffer, initialStreamData: null };
+    }
+
+    try {
+      const openedStream = await openRangeStream(
+        playInfo.musicurl,
+        range.start,
+        range.end
+      );
+      const info = parseSizeFromHeaders(openedStream.headers);
+
+      if (!info.totalSize) {
+        openedStream.stream.destroy();
+        return new Response("Could not determine file size", { status: 502 });
+      }
+
+      if (!this.isCurrentGeneration(generation, songId)) {
+        openedStream.stream.destroy();
+        return new Response("Audio play info changed", { status: 404 });
+      }
+
+      const sb = this.ensureSongBuffer(
+        songId,
+        playInfo,
+        generation,
+        playInfo.musicurl,
+        info.totalSize,
+        info.contentType
+      );
+
+      return { sb, initialStreamData: openedStream };
+    } catch {
+      return new Response("Upstream stream initialization error", {
+        status: 502,
+      });
+    }
+  }
+  // #endregion
 }

--- a/src/main/audio/streamer.ts
+++ b/src/main/audio/streamer.ts
@@ -498,9 +498,14 @@ export default class AudioStreamer extends Emittery<AudioStreamerEvents> {
     end: number,
     preOpenedStream?: OpenedRangeStream
   ): Promise<boolean> {
-    if (this.songBuffer !== sb) return false;
-    if (!canFetchRange(sb, start, end)) return false;
-    if (getRetryDelay(sb, start, end) > 0) return false;
+    if (
+      this.songBuffer !== sb ||
+      !canFetchRange(sb, start, end) ||
+      getRetryDelay(sb, start, end) > 0
+    ) {
+      preOpenedStream?.stream.destroy();
+      return false;
+    }
 
     IntervalMath.addPending(sb.pendingIntervals, [start, end]);
     let wroteBytes = false;

--- a/src/preload/calls/app.ts
+++ b/src/preload/calls/app.ts
@@ -8,6 +8,7 @@ import {
   startContinuousRecord,
   stopContinuousRecord,
 } from "../recorder";
+import { sleep } from "../../util";
 
 // These are not needed?
 registerCallHandler<[], void>("app.statis", () => {
@@ -131,7 +132,7 @@ registerCallHandler<[string], void>("app.recognizeMusic", async (guid) => {
     await startContinuousRecord(guid);
 
     for (let times = 1; times <= 5; times++) {
-      await new Promise((resolve) => setTimeout(resolve, 3000));
+      await sleep(3000);
       if (!activeRecognizeTasks.has(guid)) break;
 
       const duration = times * 3;

--- a/src/util.ts
+++ b/src/util.ts
@@ -44,3 +44,7 @@ export function imageSize(
     return [w, h];
   }
 }
+
+export async function sleep(ms: number) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -45,6 +45,6 @@ export function imageSize(
   }
 }
 
-export async function sleep(ms: number) {
-  await new Promise((resolve) => setTimeout(resolve, ms));
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
由 GPT-5.5 进行

> - Refactors src/main/audio/streamer.ts for maintainability: groups constants/types/helpers with #regions, moves pure utility logic out of the class, splits request handling into local/remote helpers, and deduplicates missing-range chunk selection/scheduling.
> - Fixes a streaming regression where the ReadableStream pull() could return after waking (on chunkwritten/bufferchange) without actually enqueuing data, resulting in no bytes being transmitted; pull() now only returns after enqueueing a chunk, closing, or erroring.