### PR TITLE
代码整体清理

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -286,7 +286,7 @@ app.on("ready", async () => {
       dialog.showErrorBox(
         "Initialization Failed",
         "An error occurred during application initialization. Open Orpheus will now exit.\n\nDetails:\n" +
-          toError(error)
+          (toError(error).stack ?? toError(error).message)
       );
     }
     app.exit(1);

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,15 +3,7 @@ import os from "node:os";
 import { mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 
-import {
-  app,
-  BrowserWindow,
-  dialog,
-  Menu,
-  protocol,
-  screen,
-  session,
-} from "electron";
+import { app, dialog, Menu, protocol, session } from "electron";
 
 import started from "electron-squirrel-startup";
 
@@ -23,7 +15,6 @@ import { onExit } from "@open-orpheus/lifecycle";
 // Handle errors as early as possible
 import "./main/error";
 
-import { getWindowSizeStatus } from "./main/util";
 import {
   data as dataDir,
   disableHardwareAccelerationFlag,
@@ -33,17 +24,16 @@ import { prepareDeviceId } from "./main/device";
 import { CORE_VERSION } from "./constants";
 import packManager from "./main/pack";
 import showPackgeDownloadWindow from "./main/windows/package-download";
-import { mainWindow, setMainWindow } from "./main/window";
+import { mainWindow } from "./main/window";
 import {
   markStarted,
   started as appStarted,
-  quitting,
   markQuitting,
 } from "./main/lifecycle";
-import { stringifyError } from "./util";
 import registerAsProtocolClient, {
   checkOpenCommand as checkWebCommand,
 } from "./main/protocol";
+import { toError } from "./util";
 
 import type WebPack from "./main/packs/WebPack";
 import type { ProxyConfiguration } from "./main/request";
@@ -107,94 +97,6 @@ if (app.isPackaged)
   // Tell Electron we don't need a menu before Electron tries to create one,
   // this benefits the startup
   Menu.setApplicationMenu(null);
-
-const createWindow = async () => {
-  // Create the browser window.
-  const mainWindow = new BrowserWindow({
-    width: 1280,
-    height: 720,
-    show: false,
-    frame: false,
-    webPreferences: {
-      preload: path.join(__dirname, "preload.js"),
-    },
-  });
-
-  const settings = (await import("./main/settings")).kv;
-
-  mainWindow.webContents.ipc.handle("audio.setDevice", async (e, deviceId) => {
-    return settings.set("audio.currentDevice", deviceId);
-  });
-
-  mainWindow.webContents.ipc.handle("audio.getDevice", async () => {
-    return settings.get("audio.currentDevice");
-  });
-
-  // Load App URL
-  mainWindow.loadURL("orpheus://orpheus/pub/app.html");
-
-  setMainWindow(mainWindow);
-
-  [
-    "maximize",
-    "minimize",
-    "restore",
-    os.platform() === "linux" ? "resize" : "resized",
-  ].forEach((event) => {
-    mainWindow.on(event as unknown as "maximize", () => {
-      // resize is triggered instead of restore on Linux (Wayland)
-      mainWindow.webContents.send(
-        "channel.call",
-        "winhelper.onSizeStatus",
-        ...getWindowSizeStatus(mainWindow)
-      );
-    });
-  });
-
-  const sendResizeDone = () => {
-    const bounds = mainWindow.getBounds();
-    mainWindow.webContents.send("channel.call", "winhelper.onsizeWindowDone", {
-      top: 0,
-      left: 0,
-      right: bounds.width,
-      bottom: bounds.height,
-      deviceScaleFaactor: screen.getDisplayMatching(bounds).scaleFactor,
-    });
-  };
-
-  if (os.platform() !== "linux") {
-    mainWindow.on("resized", sendResizeDone);
-  } else {
-    let resizeEndTimer: NodeJS.Timeout | undefined;
-
-    mainWindow.on("resize", () => {
-      if (resizeEndTimer) {
-        clearTimeout(resizeEndTimer);
-      }
-
-      // Linux does not emit "resized", so debounce "resize" to emulate resize-end.
-      resizeEndTimer = setTimeout(sendResizeDone, 150);
-    });
-  }
-
-  mainWindow.on("focus", () => {
-    mainWindow.webContents.send("channel.call", "winhelper.onfocus");
-  });
-  mainWindow.on("blur", () => {
-    mainWindow.webContents.send("channel.call", "winhelper.onlosefocus");
-  });
-
-  mainWindow.on("show", () => {
-    // Make sure mini player doesn't show together with main window
-    import("./main/windows/mini-player").then((m) => m.hideMiniPlayerWindow());
-  });
-
-  mainWindow.on("close", (e) => {
-    if (quitting) return;
-    mainWindow.webContents.send("channel.call", "winhelper.onclose");
-    e.preventDefault();
-  });
-};
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
@@ -295,8 +197,6 @@ app.on("ready", async () => {
     });
 
     await Promise.all([
-      // Initialize util module
-      import("./main/util").then((m) => m.default()),
       // Set temp dir for streamer and run cleanup
       import("./main/audio/OnlineStreamer").then(async (m) => {
         m.OnlineStreamer.tempDir = path.resolve(
@@ -314,6 +214,7 @@ app.on("ready", async () => {
       import("./main/request").then(async (m) => {
         m.setupRequestInterceptors();
 
+        // Apply stored proxy settings
         const { kv: settings } = await import("./main/settings");
         const proxy = await settings.get("proxy");
         if (typeof proxy !== "string" || !proxy) return;
@@ -369,7 +270,8 @@ app.on("ready", async () => {
       app.quit(); // Graceful exit
     });
 
-    createWindow();
+    // Create main window
+    await (await import("./main/windows/main")).default();
 
     markStarted();
 
@@ -384,28 +286,17 @@ app.on("ready", async () => {
       dialog.showErrorBox(
         "Initialization Failed",
         "An error occurred during application initialization. Open Orpheus will now exit.\n\nDetails:\n" +
-          stringifyError(error)
+          toError(error)
       );
     }
     app.exit(1);
   }
 });
 
-// Quit when all windows are closed, except on macOS. There, it's common
-// for applications and their menu bar to stay active until the user quits
-// explicitly with Cmd + Q.
 app.on("window-all-closed", () => {
   // Make sure we don't quit because of package download window being closed before main window has started
-  if (process.platform !== "darwin" && appStarted) {
+  if (appStarted) {
     app.quit();
-  }
-});
-
-app.on("activate", () => {
-  // On OS X it's common to re-create a window in the app when the
-  // dock icon is clicked and there are no other windows open.
-  if (BrowserWindow.getAllWindows().length === 0) {
-    createWindow();
   }
 });
 

--- a/src/main/afp.ts
+++ b/src/main/afp.ts
@@ -1,7 +1,9 @@
 import { createCipheriv } from "node:crypto";
 import { deflateSync } from "node:zlib";
-import { ipcMain } from "electron";
+
 import FFT from "fft.js";
+
+import { events as lifecycleEvents } from "./lifecycle";
 
 const VERSION = "hyai_1.2.0_client_1.0.0";
 const VERSION_BYTES = new TextEncoder().encode(VERSION);
@@ -316,6 +318,11 @@ export function GenerateFP(samples: Float32Array): string {
   return encryptRawFingerprint(buildRawFingerprint(duration, peaks));
 }
 
-ipcMain.handle("afp.generateFP", (_event, data: ArrayBuffer) => {
-  return GenerateFP(new Float32Array(data));
+lifecycleEvents.on("mainwindowcreated", (e) => {
+  e.data.webContents.ipc.handle(
+    "afp.generateFP",
+    (_event, data: ArrayBuffer) => {
+      return GenerateFP(new Float32Array(data));
+    }
+  );
 });

--- a/src/main/audio.ts
+++ b/src/main/audio.ts
@@ -1,7 +1,7 @@
 import path, { join } from "node:path";
 import { readFile, stat } from "node:fs/promises";
 
-import { ipcMain, Protocol } from "electron";
+import { Protocol } from "electron";
 import mime from "mime";
 
 import { OnlineStreamer } from "./audio/OnlineStreamer";
@@ -11,9 +11,11 @@ import { mainWindow } from "./window";
 import { playCacheManager } from "./cache";
 import { normalizePath, sanitizeRelativePath } from "./util";
 import { pack as packageDir } from "./folders";
-import { stringifyError } from "../util";
 import { createReadStream } from "node:fs";
 import { Readable } from "node:stream";
+import { events as lifecycleEvents } from "./lifecycle";
+import { kv as settings } from "./settings";
+import { toError } from "../util";
 
 enum AudioType {
   Local,
@@ -38,68 +40,6 @@ function sendProgress(prog: number) {
   if (!mainWindow || mainWindow.isDestroyed()) return;
   mainWindow.webContents.send("audio.onProgress", prog);
 }
-
-ipcMain.handle(
-  "audio.updatePlayInfo",
-  (event, playInfo: AudioPlayInfo | null) => {
-    if (state?.type === AudioType.URL) {
-      // We don't await this, let it destroy in background
-      state.streamer.destroy().catch((e) => {
-        console.error("Failed to destroy previous OnlineStreamer", e);
-      });
-    }
-    state = null;
-    if (!playInfo) return;
-
-    if (playInfo.type === 0) {
-      // Local File Play
-      playInfo.path = normalizePath(playInfo.path);
-      state = {
-        type: AudioType.Local,
-        playInfo,
-        path: playInfo.path,
-      };
-    } else if (playInfo.type === 4) {
-      // URL Play
-      const songId = playInfo.songId;
-      const streamer = new OnlineStreamer(playInfo.musicurl);
-
-      streamer.on("progress", (e) => {
-        sendProgress(e.data.loaded / e.data.total);
-      });
-
-      streamer.on("complete", async () => {
-        if (state?.playInfo.songId !== songId) return;
-        try {
-          const buf = await streamer.readBuffer();
-          playCacheManager
-            ?.cacheTrack(songId, buf, {
-              md5: playInfo.md5,
-              bitrate: playInfo.bitrate,
-              playInfoStr: playInfo.playInfoStr,
-              volumeGain: 0,
-              fileSize: buf.length,
-            })
-            .catch((err) => {
-              console.error("[PlayCacheManager] Failed to cache track:", err);
-            });
-        } catch (e) {
-          console.log("Cannot get streamed track:", e);
-        }
-      });
-
-      streamer.on("error", (e) => {
-        console.log("OnlineStreamer error:", e.data);
-      });
-
-      state = {
-        type: AudioType.URL,
-        playInfo,
-        streamer,
-      };
-    }
-  }
-);
 
 export default function registerAudioStreamerScheme(protocol: Protocol) {
   protocol.handle("audio", async (request) => {
@@ -165,10 +105,83 @@ export default function registerAudioStreamerScheme(protocol: Protocol) {
             },
           });
         } catch (err) {
-          return new Response(stringifyError(err), { status: 500 });
+          return new Response(toError(err).message, { status: 500 });
         }
       }
     }
     return new Response("Not Found", { status: 404 });
   });
 }
+
+lifecycleEvents.on("mainwindowcreated", (e) => {
+  const mainWindow = e.data;
+  mainWindow.webContents.ipc.handle("audio.setDevice", async (e, deviceId) => {
+    return settings.set("audio.currentDevice", deviceId);
+  });
+
+  mainWindow.webContents.ipc.handle("audio.getDevice", async () => {
+    return settings.get("audio.currentDevice");
+  });
+
+  mainWindow.webContents.ipc.handle(
+    "audio.updatePlayInfo",
+    (event, playInfo: AudioPlayInfo | null) => {
+      if (state?.type === AudioType.URL) {
+        // We don't await this, let it destroy in background
+        state.streamer.destroy().catch((e) => {
+          console.error("Failed to destroy previous OnlineStreamer", e);
+        });
+      }
+      state = null;
+      if (!playInfo) return;
+
+      if (playInfo.type === 0) {
+        // Local File Play
+        playInfo.path = normalizePath(playInfo.path);
+        state = {
+          type: AudioType.Local,
+          playInfo,
+          path: playInfo.path,
+        };
+      } else if (playInfo.type === 4) {
+        // URL Play
+        const songId = playInfo.songId;
+        const streamer = new OnlineStreamer(playInfo.musicurl);
+
+        streamer.on("progress", (e) => {
+          sendProgress(e.data.loaded / e.data.total);
+        });
+
+        streamer.on("complete", async () => {
+          if (state?.playInfo.songId !== songId) return;
+          try {
+            const buf = await streamer.readBuffer();
+            playCacheManager
+              ?.cacheTrack(songId, buf, {
+                md5: playInfo.md5,
+                bitrate: playInfo.bitrate,
+                playInfoStr: playInfo.playInfoStr,
+                volumeGain: 0,
+                fileSize: buf.length,
+              })
+              .catch((err) => {
+                console.error("[PlayCacheManager] Failed to cache track:", err);
+              });
+          } catch (e) {
+            console.log("Cannot get streamed track:", e);
+          }
+        });
+
+        streamer.on("error", (e) => {
+          console.log("OnlineStreamer error:", e.data);
+        });
+
+        state = {
+          type: AudioType.URL,
+          playInfo,
+          streamer,
+        };
+      }
+    }
+  );
+});

--- a/src/main/audio/DownloadScheduler.ts
+++ b/src/main/audio/DownloadScheduler.ts
@@ -1,5 +1,7 @@
 import got from "got";
 
+import { toError } from "../../util";
+
 import type ChunkTracker from "./ChunkTracker";
 import type StorageManager from "./StorageManager";
 
@@ -464,11 +466,6 @@ export default class DownloadScheduler {
     this.completeEmitted = true;
     this.onComplete();
   }
-}
-
-function toError(error: unknown) {
-  if (error instanceof Error) return error;
-  return new Error(String(error));
 }
 
 function isFatalBackgroundError(error: Error) {

--- a/src/main/audio/OnlineStreamer.ts
+++ b/src/main/audio/OnlineStreamer.ts
@@ -7,6 +7,8 @@ import { randomUUID } from "node:crypto";
 import Emittery from "emittery";
 import got from "got";
 
+import { toError } from "../../util";
+
 import ChunkTracker from "./ChunkTracker";
 import DownloadScheduler from "./DownloadScheduler";
 import StorageManager from "./StorageManager";
@@ -458,9 +460,4 @@ function normalizeBoundary(value: number) {
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
-}
-
-function toError(error: unknown) {
-  if (error instanceof Error) return error;
-  return new Error(String(error));
 }

--- a/src/main/calls/browser.ts
+++ b/src/main/calls/browser.ts
@@ -1,4 +1,3 @@
-import { stringifyError } from "../../util";
 import { registerCallHandler } from "../calls";
 import { getCookies, getFullCookies, removeCookie, setCookie } from "../cookie";
 
@@ -89,7 +88,7 @@ registerCallHandler<[SetCookie], [boolean]>(
         sameSite: cookie.samesite,
       });
     } catch (error) {
-      console.error(`Error setting cookie: ${stringifyError(error)}`);
+      console.error(`Error setting cookie:`, error);
       return [false];
     }
     return [true];

--- a/src/main/calls/storage.ts
+++ b/src/main/calls/storage.ts
@@ -36,7 +36,7 @@ import createCacheManager, {
   lyricCacheManager,
   playCacheManager,
 } from "../cache";
-import { stringifyError } from "../../util";
+import { toError } from "../../util";
 import { deData, enData, ID3_AES_KEY } from "../crypto";
 
 const ID3_COMMENT_PREFIX = "163 key(Don't modify):";
@@ -72,9 +72,7 @@ async function readDownloadedMusicInfo(
     if (!decryptedComment) return;
     comment = decryptedComment ? decryptedComment.toString("utf-8") : "";
   } catch (error) {
-    console.error(
-      `Error reading ID3 tags from ${filePath}: ${stringifyError(error)}`
-    );
+    console.error(`Error reading ID3 tags from ${filePath}:`, error);
   }
   const statResult = await stat(filePath);
   return {
@@ -156,7 +154,7 @@ registerCallHandler<[string, string], void>(
         ...execResult
       );
     } catch (error) {
-      console.error(`Error executing SQL: ${stringifyError(error)}`);
+      console.error(`Error executing SQL:`, error);
       event.sender.send(
         "channel.call",
         "storage.onexecsqldone",
@@ -181,9 +179,7 @@ registerCallHandler<[string, string], void>(
         ...execResult
       );
     } catch (error) {
-      console.error(
-        `Error executing SQL transaction: ${stringifyError(error)}`
-      );
+      console.error(`Error executing SQL transaction:`, error);
       event.sender.send(
         "channel.call",
         "storage.onexecsqldone",
@@ -224,7 +220,7 @@ registerCallHandler<
         "storage.onsavetofiledone",
         taskId,
         -1,
-        stringifyError(error)
+        toError(error).message
       );
     }
   }
@@ -342,9 +338,7 @@ registerCallHandler<[string, boolean, string, number, string[]], void>(
 
         flush();
       } catch (err) {
-        console.error(
-          `DownloadScanner: scanner path ${path}: ${stringifyError(err)}`
-        );
+        console.error(`DownloadScanner: scanner path ${path}:`, err);
       }
     })();
   }
@@ -414,9 +408,7 @@ registerCallHandler<[string], void>(
     try {
       content = (await lyricCacheManager?.get(songId)) ?? "";
     } catch (error) {
-      console.error(
-        `Error reading temp file for songId ${songId}: ${stringifyError(error)}`
-      );
+      console.error(`Error reading temp file for songId ${songId}:`, error);
     }
     event.sender.send(
       "channel.call",
@@ -441,9 +433,7 @@ registerCallHandler<[string, string, string], void>(
     try {
       await lyricCacheManager.set(songId, content);
     } catch (error) {
-      console.error(
-        `Error writing temp file for songId ${songId}: ${stringifyError(error)}`
-      );
+      console.error(`Error writing temp file for songId ${songId}:`, error);
     }
   }
 );
@@ -612,7 +602,7 @@ async function handleFileBatch(
       })
     );
   } catch (error) {
-    console.error(`Error when ${type} files: ${stringifyError(error)}`);
+    console.error(`Error when ${type} files:`, error);
     event.sender.send("channel.call", `storage.on${type}process`, {
       code: 1,
       state: srcPaths.length - processedCount,

--- a/src/main/lifecycle.ts
+++ b/src/main/lifecycle.ts
@@ -1,10 +1,36 @@
+import { BrowserWindow } from "electron";
+import Emittery from "emittery";
+
+export type LifecycleEvents = {
+  /**
+   * This event fires when main window has just been created, and the content
+   * is not loaded yet.
+   *
+   * Note that in this event, `mainWindow` is not set yet, but you can get it
+   * in the event data.
+   */
+  mainwindowcreated: BrowserWindow;
+  /**
+   * This event fires when app is fully started and ready.
+   *
+   * At this point, `mainWindow` should be fully available to use, if not,
+   * something's seriously wrong.
+   */
+  started: undefined;
+  quitting: undefined;
+};
+
+export const events = new Emittery<LifecycleEvents>();
+
 export let started = false;
 export let quitting = false;
 
 export function markStarted() {
   started = true;
+  events.emit("started");
 }
 
 export function markQuitting() {
   quitting = true;
+  events.emit("quitting");
 }

--- a/src/main/lifecycle.ts
+++ b/src/main/lifecycle.ts
@@ -27,10 +27,10 @@ export let quitting = false;
 
 export function markStarted() {
   started = true;
-  events.emit("started");
+  events.emit("started").catch(console.error);
 }
 
 export function markQuitting() {
   quitting = true;
-  events.emit("quitting");
+  events.emit("quitting").catch(console.error);
 }

--- a/src/main/lyrics.ts
+++ b/src/main/lyrics.ts
@@ -1,15 +1,18 @@
-import { ipcMain } from "electron";
-
+import { events as lifecycleEvents } from "./lifecycle";
 import LyricsDispatcher from "./lyrics/LyricsDispatcher";
 
 export const lyricsDispatcher = new LyricsDispatcher();
 
 // Lyrics update events are handled in calls.
 
-ipcMain.on("lyrics.setPlayState", (event, playState) => {
-  lyricsDispatcher.playState = playState;
-});
+lifecycleEvents.on("mainwindowcreated", (e) => {
+  const mainWindow = e.data;
 
-ipcMain.on("lyrics.setTime", (event, time) => {
-  lyricsDispatcher.time = time;
+  mainWindow.webContents.ipc.on("lyrics.setPlayState", (event, playState) => {
+    lyricsDispatcher.playState = playState;
+  });
+
+  mainWindow.webContents.ipc.on("lyrics.setTime", (event, time) => {
+    lyricsDispatcher.time = time;
+  });
 });

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -3,16 +3,10 @@ import { stat } from "node:fs/promises";
 import os from "node:os";
 
 import { BrowserWindow, screen } from "electron";
-
-let photon: typeof import("@silvia-odwyer/photon-node") | null = null;
-let mime: typeof import("mime") | null = null;
-
-function ensureModule<T>(mod: T): asserts mod is NonNullable<T> {
-  if (!mod) throw new Error("util is not initialized");
-}
+import photon from "@silvia-odwyer/photon-node";
+import mime from "mime";
 
 export function pngFromIco(icoData: Uint8Array): Uint8Array {
-  ensureModule(photon);
   const icoImage = photon.PhotonImage.new_from_byteslice(icoData);
   const pngData = icoImage.get_bytes();
   return pngData;
@@ -41,39 +35,13 @@ export function sanitizeRelativePath(
   return resolvedPath;
 }
 
-export function getWindowState(
-  wnd: BrowserWindow
-): "minimize" | "maximize" | "restore" {
-  return wnd.isMinimized()
-    ? "minimize"
-    : wnd.isMaximized()
-      ? "maximize"
-      : "restore";
-}
-
-export function getWindowSizeStatus(
-  wnd: BrowserWindow
-): ["minimize" | "maximize" | "restore", number, number, number] {
-  const bounds = wnd.getBounds();
-  const screenScaleFactor = screen.getDisplayMatching(bounds).scaleFactor;
-  // TODO: Confirm macOS desired behavior, Windows and Linux (Wayland) is already tested to be correct
-  const scaleFactor = os.platform() === "win32" ? 1 : screenScaleFactor;
-  return [
-    getWindowState(wnd),
-    bounds.width * scaleFactor,
-    bounds.height * scaleFactor,
-    screenScaleFactor,
-  ];
-}
-
 export function getWindowScaleFactor(wnd: BrowserWindow): number {
   const bounds = wnd.getBounds();
   return screen.getDisplayMatching(bounds).scaleFactor;
 }
 
 export function isMusicFile(fileOrPath: string): boolean {
-  ensureModule(mime);
-  return mime.default.getType(fileOrPath)?.startsWith("audio/") || false;
+  return mime.getType(fileOrPath)?.startsWith("audio/") || false;
 }
 
 export async function calculateDbSize(db: string): Promise<number> {
@@ -94,11 +62,4 @@ export async function calculateDbSize(db: string): Promise<number> {
   ]);
 
   return sizeBytes;
-}
-
-export default async function initialize() {
-  [photon, mime] = await Promise.all([
-    import("@silvia-odwyer/photon-node"),
-    import("mime"),
-  ]);
 }

--- a/src/main/windows/main.ts
+++ b/src/main/windows/main.ts
@@ -1,0 +1,120 @@
+import os from "node:os";
+import path from "node:path";
+
+import { BrowserWindow, screen } from "electron";
+
+import { setMainWindow } from "../window";
+import { hideMiniPlayerWindow } from "./mini-player";
+import { events as lifecycleEvents, quitting } from "../lifecycle";
+
+function getWindowState(
+  wnd: BrowserWindow
+): "minimize" | "maximize" | "restore" {
+  return wnd.isMinimized()
+    ? "minimize"
+    : wnd.isMaximized()
+      ? "maximize"
+      : "restore";
+}
+
+function getWindowSizeStatus(
+  wnd: BrowserWindow
+): ["minimize" | "maximize" | "restore", number, number, number] {
+  const bounds = wnd.getBounds();
+  const screenScaleFactor = screen.getDisplayMatching(bounds).scaleFactor;
+  // TODO: Confirm macOS desired behavior, Windows and Linux (Wayland) is already tested to be correct
+  const scaleFactor = os.platform() === "win32" ? 1 : screenScaleFactor;
+  return [
+    getWindowState(wnd),
+    bounds.width * scaleFactor,
+    bounds.height * scaleFactor,
+    screenScaleFactor,
+  ];
+}
+
+export default async function createMainWindow() {
+  // Create the browser window.
+  const mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 720,
+    show: false,
+    frame: false,
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+    },
+  });
+
+  [
+    "maximize",
+    "minimize",
+    "restore",
+    os.platform() === "linux" ? "resize" : "resized",
+  ].forEach((event) => {
+    mainWindow.on(event as unknown as "maximize", () => {
+      // resize is triggered instead of restore on Linux (Wayland)
+      mainWindow.webContents.send(
+        "channel.call",
+        "winhelper.onSizeStatus",
+        ...getWindowSizeStatus(mainWindow)
+      );
+    });
+  });
+
+  const sendResizeDone = () => {
+    const bounds = mainWindow.getBounds();
+    mainWindow.webContents.send("channel.call", "winhelper.onsizeWindowDone", {
+      top: 0,
+      left: 0,
+      right: bounds.width,
+      bottom: bounds.height,
+      deviceScaleFaactor: screen.getDisplayMatching(bounds).scaleFactor,
+    });
+  };
+
+  if (os.platform() !== "linux") {
+    mainWindow.on("resized", sendResizeDone);
+  } else {
+    let resizeEndTimer: NodeJS.Timeout | undefined;
+
+    mainWindow.on("resize", () => {
+      if (resizeEndTimer) {
+        clearTimeout(resizeEndTimer);
+      }
+
+      // Linux does not emit "resized", so debounce "resize" to emulate resize-end.
+      resizeEndTimer = setTimeout(sendResizeDone, 150);
+    });
+  }
+
+  mainWindow.on("focus", () => {
+    mainWindow.webContents.send("channel.call", "winhelper.onfocus");
+  });
+  mainWindow.on("blur", () => {
+    mainWindow.webContents.send("channel.call", "winhelper.onlosefocus");
+  });
+
+  mainWindow.on("show", () => {
+    // Make sure mini player doesn't show together with main window
+    hideMiniPlayerWindow();
+  });
+
+  mainWindow.on("close", (e) => {
+    if (quitting) return;
+    mainWindow.webContents.send("channel.call", "winhelper.onclose");
+    e.preventDefault();
+  });
+
+  try {
+    await lifecycleEvents.emit("mainwindowcreated", mainWindow);
+  } catch (err) {
+    console.error(
+      "Some of 'mainwindowcreated' event listeners failed to run:",
+      err
+    );
+  }
+
+  // Load App URL
+  mainWindow.loadURL("orpheus://orpheus/pub/app.html");
+
+  setMainWindow(mainWindow);
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,11 +1,6 @@
-export function stringifyError(error: unknown): string {
-  if (typeof error === "string") {
-    return error;
-  }
-  if (error instanceof Error) {
-    return error.message + "\n" + error.stack;
-  }
-  return String(error);
+export function toError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  return new Error(String(error));
 }
 
 /**


### PR DESCRIPTION
一些变更说明：
- 将主窗口创建移出`main.ts`
- `main.ts`目前不再直接import `util`，不再影响Electron初始化，`util`可以自由提前加载外部模块
- macOS下，将应用生命周期与主窗口绑定（这是设计决定），不使用Electron脚手架代码行为
- 进一步收缩主窗口以外的preload脚本权限