### PR TITLE
重构 Linux 下托盘图标交互逻辑

### DIFF
--- a/gui/src/routes/Tray.svelte
+++ b/gui/src/routes/Tray.svelte
@@ -6,13 +6,13 @@
   type TrayClickBehavior =
     | "depends-on-main-window"
     | "always-show-menu"
-    | "with-native-menu";
+    | "always-show-main-window";
 
   let clickBehaviorPromise = $state(settings.get("tray.clickBehavior"));
 </script>
 
-<h1 class="text-2xl font-bold">托盘菜单</h1>
-<p class="mt-2 text-gray-700">选择托盘菜单如何响应你的操作。</p>
+<h1 class="text-2xl font-bold">托盘图标</h1>
+<p class="mt-2 text-gray-700">选择托盘图标如何响应你的左键点击（激活）。</p>
 
 {#await clickBehaviorPromise then value}
   <RadioGroup.Root
@@ -50,15 +50,18 @@
         <RadioGroup.Item id="always-show-menu" value="always-show-menu" />
       </Field.Field>
     </Field.Label>
-    <Field.Label for="with-native-menu">
+    <Field.Label for="always-show-main-window">
       <Field.Field orientation="horizontal">
         <Field.Content>
-          <Field.Title>使用原生菜单</Field.Title>
+          <Field.Title>总是打开主窗口</Field.Title>
           <Field.Description>
-            无论主窗口状态如何，点击托盘图标都会显示主窗口。右击托盘图标会显示一个原生菜单，仅包含“显示菜单”选项，用于呼出菜单。
+            无论主窗口状态如何，点击托盘图标都会打开主窗口。
           </Field.Description>
         </Field.Content>
-        <RadioGroup.Item id="with-native-menu" value="with-native-menu" />
+        <RadioGroup.Item
+          id="always-show-main-window"
+          value="always-show-main-window"
+        />
       </Field.Field>
     </Field.Label>
   </RadioGroup.Root>

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,11 +25,6 @@ import { CORE_VERSION } from "./constants";
 import packManager from "./main/pack";
 import showPackgeDownloadWindow from "./main/windows/package-download";
 import { mainWindow } from "./main/window";
-import {
-  markStarted,
-  started as appStarted,
-  markQuitting,
-} from "./main/lifecycle";
 import registerAsProtocolClient, {
   checkOpenCommand as checkWebCommand,
 } from "./main/protocol";
@@ -37,6 +32,11 @@ import { toError } from "./util";
 
 import type WebPack from "./main/packs/WebPack";
 import type { ProxyConfiguration } from "./main/request";
+import {
+  LifecycleState,
+  setLifecycleState,
+  state as lifecycleState,
+} from "./main/lifecycle";
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (started) {
@@ -197,6 +197,8 @@ app.on("ready", async () => {
     });
 
     await Promise.all([
+      // Install the tray icon
+      import("./main/tray"),
       // Set temp dir for streamer and run cleanup
       import("./main/audio/OnlineStreamer").then(async (m) => {
         m.OnlineStreamer.tempDir = path.resolve(
@@ -273,8 +275,6 @@ app.on("ready", async () => {
     // Create main window
     await (await import("./main/windows/main")).default();
 
-    markStarted();
-
     // TODO: Maybe only do this on first launch?
     // Register as orpheus:// clent
     registerAsProtocolClient();
@@ -295,14 +295,14 @@ app.on("ready", async () => {
 
 app.on("window-all-closed", () => {
   // Make sure we don't quit because of package download window being closed before main window has started
-  if (appStarted) {
+  if (lifecycleState !== LifecycleState.Starting) {
     app.quit();
   }
 });
 
 app.on("before-quit", () => {
   // Allow some windows to be closed.
-  markQuitting();
+  setLifecycleState(LifecycleState.Quitting);
 });
 
 app.on("second-instance", (event, argv) => {

--- a/src/main/calls/app.ts
+++ b/src/main/calls/app.ts
@@ -19,6 +19,7 @@ import { kv as settings } from "../settings";
 import type { ProxyConfiguration, ProxyTypes } from "../request";
 import client, { getProxyAgent } from "../request";
 import { disableHardwareAccelerationFlag } from "../folders";
+import { LifecycleState, setLifecycleState } from "../lifecycle";
 
 registerCallHandler<string[], void>("app.log", (_ev, ...args) => {
   console.log(...args);
@@ -247,7 +248,7 @@ registerCallHandler<
   /* empty */
 });
 registerCallHandler<[], void>("app.appStartUpEnd", () => {
-  /* empty */
+  setLifecycleState(LifecycleState.Started);
 });
 
 registerCallHandler<[], [boolean]>("app.isRegisterDefaultClient", () => [

--- a/src/main/calls/trayicon.ts
+++ b/src/main/calls/trayicon.ts
@@ -1,45 +1,15 @@
-import os from "node:os";
-
-import { Menu, MenuItem, nativeImage } from "electron";
+import { nativeImage } from "electron";
 
 import { pngFromIco } from "../util";
 import { loadFromOrpheusUrl } from "../orpheus";
-import { get, install, setIcon, setMenu, setTooltip, uninstall } from "../tray";
+import {
+  install,
+  setIcon,
+  setTooltip,
+  trayInstalled,
+  uninstall,
+} from "../tray";
 import { registerCallHandler } from "../calls";
-import * as settings from "../settings";
-import { mainWindow } from "../window";
-
-if (os.platform() === "linux") {
-  function onClickBehaviorUpdate(value: unknown) {
-    if (value === "with-native-menu") {
-      const menu = new Menu();
-      menu.append(
-        new MenuItem({
-          label: "显示菜单",
-          click: () => {
-            mainWindow?.webContents.send(
-              "channel.call",
-              "trayicon.onrightclick"
-            );
-          },
-        })
-      );
-      setMenu(menu);
-    } else {
-      setMenu(null);
-    }
-  }
-  settings.events.on("change", (event) => {
-    const { key, value } = event.data;
-    if (key === "tray.clickBehavior") {
-      onClickBehaviorUpdate(value);
-    }
-  });
-  settings.kv
-    .get("tray.clickBehavior")
-    .then((v) => onClickBehaviorUpdate(v))
-    .catch(console.error);
-}
 
 registerCallHandler<[string], void>(
   "trayicon.setIcon",
@@ -56,7 +26,7 @@ registerCallHandler<[string], void>("trayicon.setToolTip", (event, tooltip) => {
 });
 
 registerCallHandler<[], [boolean]>("trayicon.wasInstall", () => {
-  return [get() !== null];
+  return [trayInstalled];
 });
 
 registerCallHandler<[], void>("trayicon.install", () => {

--- a/src/main/calls/winhelper.ts
+++ b/src/main/calls/winhelper.ts
@@ -20,9 +20,9 @@ import {
   setMinimumSize,
 } from "../window";
 import AppMenu from "../menu";
-import showManageWindow from "../windows/manage";
 import { registerGlobalShortcut, unregisterGlobalShortcut } from "../shortcuts";
 import * as settings from "../settings";
+import { LifecycleState, setLifecycleState } from "../lifecycle";
 
 function shouldApplyScaleFactor() {
   const de = getDesktopEnvironment();
@@ -97,8 +97,12 @@ registerCallHandler<[string], void>(
 registerCallHandler<[], void>("winhelper.initMainWindow", () => {
   return;
 });
-registerCallHandler<[], void>("winhelper.finishLoadMainWindow", () => {
-  return;
+registerCallHandler<[], void>("winhelper.finishLoadMainWindow", (event) => {
+  // Window cannot be not existing at this time
+  setLifecycleState(
+    LifecycleState.MainWindowLoaded,
+    BrowserWindow.fromWebContents(event.sender)!
+  );
 });
 
 type WindowPosition = {
@@ -374,22 +378,6 @@ registerCallHandler<MenuRequest, void>(
       (await settings.kv.get("tray.clickBehavior")) === "always-show-menu";
     for (let i = 0; i < parsedMenuData.content.length; i++) {
       const item = parsedMenuData.content[i];
-      // Inject "Manage Open Orpheus" menu item before "Settings" menu item
-      if (
-        item.image_path &&
-        item.image_path.indexOf("menu/setting.svg") !== -1
-      ) {
-        parsedMenuData.content.splice(i + 1, 0, {
-          menu: true,
-          separator: false,
-          enable: true,
-          children: null,
-          image_color: "#00000000",
-          menu_id: "openOrpheus.manage",
-          text: "管理 Open Orpheus",
-        });
-        i++; // Skip the injected menu item
-      }
       // Inject show main window menu item if tray.clickBehavior is "always-show-menu"
       if (injectShowMainWindowMenuItem && item.menu_id === "exitApp") {
         parsedMenuData.content.splice(i, 0, {
@@ -405,10 +393,6 @@ registerCallHandler<MenuRequest, void>(
       }
     }
     const onClick = (itemId: string | null) => {
-      if (itemId === "openOrpheus.manage") {
-        showManageWindow();
-        return;
-      }
       if (itemId === "openOrpheus.showMainWindow") {
         event.sender.send("channel.call", "trayicon.onclick");
         return;

--- a/src/main/lifecycle.ts
+++ b/src/main/lifecycle.ts
@@ -1,6 +1,14 @@
 import { BrowserWindow } from "electron";
 import Emittery from "emittery";
 
+export enum LifecycleState {
+  Starting,
+  MainWindowCreated,
+  MainWindowLoaded,
+  Started,
+  Quitting,
+}
+
 export type LifecycleEvents = {
   /**
    * This event fires when main window has just been created, and the content
@@ -10,6 +18,7 @@ export type LifecycleEvents = {
    * in the event data.
    */
   mainwindowcreated: BrowserWindow;
+  mainwindowloaded: BrowserWindow;
   /**
    * This event fires when app is fully started and ready.
    *
@@ -20,17 +29,36 @@ export type LifecycleEvents = {
   quitting: undefined;
 };
 
+const STATE_EVENT_MAP = {
+  [LifecycleState.MainWindowCreated]: "mainwindowcreated",
+  [LifecycleState.MainWindowLoaded]: "mainwindowloaded",
+  [LifecycleState.Started]: "started",
+  [LifecycleState.Quitting]: "quitting",
+} as const satisfies Partial<Record<LifecycleState, string>>;
+
 export const events = new Emittery<LifecycleEvents>();
+export let state = LifecycleState.Starting;
 
-export let started = false;
-export let quitting = false;
+type StateEventData = {
+  [K in keyof typeof STATE_EVENT_MAP]: LifecycleEvents[(typeof STATE_EVENT_MAP)[K] &
+    keyof LifecycleEvents];
+};
 
-export function markStarted() {
-  started = true;
-  events.emit("started").catch(console.error);
-}
-
-export function markQuitting() {
-  quitting = true;
-  events.emit("quitting").catch(console.error);
+export function setLifecycleState<K extends LifecycleState>(
+  lifecycleState: K,
+  ...args: K extends keyof StateEventData
+    ? [undefined] extends [StateEventData[K]]
+      ? [eventData?: StateEventData[K]]
+      : [eventData: StateEventData[K]]
+    : []
+): void {
+  state = lifecycleState;
+  const event = STATE_EVENT_MAP[lifecycleState as keyof typeof STATE_EVENT_MAP];
+  if (!event) return;
+  events
+    .emit(
+      event as keyof LifecycleEvents,
+      args[0] as LifecycleEvents[keyof LifecycleEvents]
+    )
+    .catch(console.error);
 }

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -101,14 +101,14 @@ async function clickHandler() {
   if (!mainWindow || mainWindow.isDestroyed()) return;
   // Linux can only receives click, so a different behavior is used
   // The `onclick` will be send when main window is invisible, and `onrightclick` will be send when main window is visible
+  const clickBehavior = await settings.get("tray.clickBehavior");
   mainWindow.webContents.send(
     "channel.call",
     // We only send rightclick here if is Linux, the main window is visible, and the user has not set the click behavior to "always-show-main-window",
     // or, on Linux, if the user has set the click behavior to "always-show-menu", in which case we always send rightclick to show the menu
     os.platform() !== "linux" ||
-      ((await settings.get("tray.clickBehavior")) !== "always-show-menu" &&
-        !mainWindow.isVisible()) ||
-      (await settings.get("tray.clickBehavior")) === "always-show-main-window"
+      (clickBehavior !== "always-show-menu" && !mainWindow.isVisible()) ||
+      clickBehavior === "always-show-main-window"
       ? "trayicon.onclick"
       : "trayicon.onrightclick"
   );

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -1,19 +1,69 @@
 import os from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 
-import { Menu, nativeImage, NativeImage, Tray } from "electron";
+import {
+  app,
+  Menu,
+  MenuItemConstructorOptions,
+  nativeImage,
+  NativeImage,
+  Tray,
+} from "electron";
 
 import { mainWindow } from "./window";
 import { kv as settings } from "./settings";
 
+import showManageWindow from "./windows/manage";
+
+import iconFilename from "../../assets/icon_256.png?no-inline";
+
+let quitRequested = false;
+
+const defaultIconPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  `.${iconFilename}`
+);
+const defaultMenuItems: MenuItemConstructorOptions[] = [
+  {
+    label: "管理 Open Orpheus",
+    click: () => {
+      showManageWindow();
+    },
+  },
+  {
+    label: "退出",
+    click: () => {
+      if (
+        trayInstalled &&
+        !quitRequested &&
+        mainWindow &&
+        !mainWindow.isDestroyed()
+      ) {
+        // NCM seems to be ready, and is not , we will go with graceful way as of now
+        mainWindow.webContents.send(
+          "channel.call",
+          "winhelper.onmenuclick",
+          "exitApp",
+          0
+        );
+        quitRequested = true;
+        return;
+      }
+      app.quit();
+    },
+  },
+];
+
+export let trayInstalled = false;
+
 let icon: NativeImage | null = null;
 let tooltip: string | null = null;
-let menu: Menu | null = null;
 
-let trayIcon: Tray | null = null;
+const trayIcon = new Tray(defaultIconPath);
 
-export function get(): Tray | null {
-  return trayIcon;
-}
+trayIcon.setToolTip("Open Orpheus 启动中");
+trayIcon.setContextMenu(Menu.buildFromTemplate(defaultMenuItems));
 
 export function setIcon(newIcon: NativeImage) {
   if (os.platform() === "darwin") {
@@ -47,53 +97,77 @@ export function setTooltip(newTooltip: string) {
   }
 }
 
-export function setMenu(newMenu: Menu | null) {
-  menu = newMenu;
-  if (trayIcon) {
-    trayIcon.setContextMenu(newMenu);
-  }
+async function clickHandler() {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  // Linux can only receives click, so a different behavior is used
+  // The `onclick` will be send when main window is invisible, and `onrightclick` will be send when main window is visible
+  mainWindow.webContents.send(
+    "channel.call",
+    // We only send rightclick here if is Linux, the main window is visible, and the user has not set the click behavior to "always-show-main-window",
+    // or, on Linux, if the user has set the click behavior to "always-show-menu", in which case we always send rightclick to show the menu
+    os.platform() !== "linux" ||
+      ((await settings.get("tray.clickBehavior")) !== "always-show-menu" &&
+        !mainWindow.isVisible()) ||
+      (await settings.get("tray.clickBehavior")) === "always-show-main-window"
+      ? "trayicon.onclick"
+      : "trayicon.onrightclick"
+  );
+}
+
+function rightClickHandler() {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  mainWindow.webContents.send("channel.call", "trayicon.onrightclick");
 }
 
 export function install() {
-  if (trayIcon) {
-    throw new Error("Tray icon already installed");
+  if (trayInstalled) {
+    throw new Error("NCM already installed the tray icon");
   }
   if (!icon) {
     throw new Error("Tray icon not initialized");
   }
-  trayIcon = new Tray(icon);
+  trayIcon.setImage(icon);
   if (tooltip) {
     trayIcon.setToolTip(tooltip);
+  } else {
+    trayIcon.setToolTip("");
   }
-  if (menu) {
-    trayIcon.setContextMenu(menu);
-  }
-  trayIcon.on("click", async () => {
-    if (!mainWindow) return;
-    // Linux can only receives click, so a different behavior is used
-    // The `onclick` will be send when main window is invisible, and `onrightclick` will be send when main window is visible
-    mainWindow.webContents.send(
-      "channel.call",
-      // We only send rightclick here if is Linux, the main window is visible, and the user has not set the click behavior to "with-native-menu",
-      // or, on Linux, if the user has set the click behavior to "always-show-menu", in which case we always send rightclick to show the menu
-      os.platform() !== "linux" ||
-        ((await settings.get("tray.clickBehavior")) !== "always-show-menu" &&
-          !mainWindow.isVisible()) ||
-        (await settings.get("tray.clickBehavior")) === "with-native-menu"
-        ? "trayicon.onclick"
-        : "trayicon.onrightclick"
+  trayIcon.on("click", clickHandler);
+  trayIcon.on("right-click", rightClickHandler);
+  if (os.platform() === "linux") {
+    trayIcon.setContextMenu(
+      Menu.buildFromTemplate([
+        {
+          label: "显示网易云音乐菜单",
+          click: () => {
+            // Although it can't be non-existing...
+            if (!mainWindow || mainWindow.isDestroyed()) return;
+            mainWindow.webContents.send(
+              "channel.call",
+              "trayicon.onrightclick"
+            );
+          },
+        },
+        {
+          type: "separator",
+        },
+        ...defaultMenuItems,
+      ])
     );
-  });
-  trayIcon.on("right-click", () => {
-    if (!mainWindow) return;
-    mainWindow.webContents.send("channel.call", "trayicon.onrightclick");
-  });
+  } else {
+    trayIcon.setContextMenu(null);
+  }
+  trayInstalled = true;
 }
 
 export function uninstall() {
-  if (!trayIcon) {
+  if (!trayInstalled) {
     throw new Error("Tray icon not installed");
   }
-  trayIcon.destroy();
-  trayIcon = null;
+  trayIcon.setToolTip("");
+  trayIcon.off("click", clickHandler);
+  trayIcon.off("right-click", rightClickHandler);
+  trayIcon.setImage(defaultIconPath);
+  trayIcon.setContextMenu(Menu.buildFromTemplate(defaultMenuItems));
+  trayInstalled = false;
 }

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -85,14 +85,14 @@ export function setIcon(newIcon: NativeImage) {
     newIcon = image;
   }
   icon = newIcon;
-  if (trayIcon) {
+  if (trayInstalled) {
     trayIcon.setImage(newIcon);
   }
 }
 
 export function setTooltip(newTooltip: string) {
   tooltip = newTooltip;
-  if (trayIcon) {
+  if (trayInstalled) {
     trayIcon.setToolTip(newTooltip);
   }
 }

--- a/src/main/windows/desktop-lyrics.ts
+++ b/src/main/windows/desktop-lyrics.ts
@@ -12,7 +12,7 @@ import {
 } from "$sharedTypes/desktop-lyrics";
 
 import { mainWindow, setWindowId } from "../window";
-import { quitting } from "../lifecycle";
+import { LifecycleState, state as lifecycleState } from "../lifecycle";
 import { registerIpcHandlers } from "../../bridge/register";
 import type {
   DesktopLyricsContract,
@@ -109,7 +109,7 @@ export default function createDesktopLyricsWindow() {
   setWindowId(desktopLyricsWindow, "desktop_lyrics");
 
   desktopLyricsWindow.on("close", (e) => {
-    if (quitting) return; // If the app is quitting we allow the window to close
+    if (lifecycleState === LifecycleState.Quitting) return; // If the app is quitting we allow the window to close
     // Not closing, but telling NCM to hide.
     e.preventDefault();
     performAction("close");

--- a/src/main/windows/main.ts
+++ b/src/main/windows/main.ts
@@ -5,7 +5,11 @@ import { BrowserWindow, screen } from "electron";
 
 import { setMainWindow } from "../window";
 import { hideMiniPlayerWindow } from "./mini-player";
-import { events as lifecycleEvents, quitting } from "../lifecycle";
+import {
+  LifecycleState,
+  state as lifecycleState,
+  setLifecycleState,
+} from "../lifecycle";
 
 function getWindowState(
   wnd: BrowserWindow
@@ -99,19 +103,12 @@ export default async function createMainWindow() {
   });
 
   mainWindow.on("close", (e) => {
-    if (quitting) return;
+    if (lifecycleState === LifecycleState.Quitting) return;
     mainWindow.webContents.send("channel.call", "winhelper.onclose");
     e.preventDefault();
   });
 
-  try {
-    await lifecycleEvents.emit("mainwindowcreated", mainWindow);
-  } catch (err) {
-    console.error(
-      "Some of 'mainwindowcreated' event listeners failed to run:",
-      err
-    );
-  }
+  setLifecycleState(LifecycleState.MainWindowCreated, mainWindow);
 
   // Load App URL
   mainWindow.loadURL("orpheus://orpheus/pub/app.html");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
+    "types": ["vite/client"],
     "paths": {
       "$sharedTypes/*": ["./types/*"]
     }


### PR DESCRIPTION
related #124

顺带提供了在 NCM 加载失败/卡死时退出的方法，并引入了更精细的生命周期管理