### PR TITLE
修复Linux下软件无法启动（Initialization Failed）

### DIFF
--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -1,6 +1,5 @@
 import os from "node:os";
-import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
+import { resolve } from "node:path";
 
 import {
   app,
@@ -20,10 +19,7 @@ import iconFilename from "../../assets/icon_256.png?no-inline";
 
 let quitRequested = false;
 
-const defaultIconPath = resolve(
-  dirname(fileURLToPath(import.meta.url)),
-  `.${iconFilename}`
-);
+const defaultIconPath = resolve(__dirname, `.${iconFilename}`);
 const defaultMenuItems: MenuItemConstructorOptions[] = [
   {
     label: "管理 Open Orpheus",


### PR DESCRIPTION
#131 合并之后出现的问题
Linux下打包后启动时会初始化报错（如下图）
<img width="585" height="590" alt="image" src="https://github.com/user-attachments/assets/bd988cd5-e8be-40a3-a983-f099ea9b8c07" />
观察新改动的tray，
```javascript
const defaultIconPath = resolve(
  dirname(fileURLToPath(import.meta.url)),
  `.${iconFilename}`
);
```
编译结果变成了这样
```javascript
var defaultIconPath = (0, node_path.resolve)((0, node_path.dirname)((0, node_url.fileURLToPath)({}.url)), `.${icon_256_default}`);
```
`fileURLToPath({}.url) = fileURLToPath(undefined)` 触发报错
目前来看主进程编译结果还是 CommonJS ，于是换成了
```javascript
const defaultIconPath = resolve(__dirname, `.${iconFilename}`);
```
测试修改后软件正常开启，托盘图标启动时显示本软件图标，完全启动后变为网易云音乐的，不知是否符合预期