### PR TITLE
本地文件夹分隔符错误

### DIFF
--- a/src/main/calls/musiclibrary.ts
+++ b/src/main/calls/musiclibrary.ts
@@ -52,7 +52,7 @@ function getLibraryPath(library: MusicLibraries): string | null {
     case "<itunes>":
       return null;
     default:
-      return library;
+      return normalizePath(library);
   }
 }
 
@@ -139,7 +139,7 @@ registerCallHandler<[MusicLibraries], void>(
   (event, lib) => {
     if (libWatchers.has(lib)) return;
     const libPath = getLibraryPath(lib);
-    if (!libPath) return;
+    if (!libPath || !existsSync(libPath)) return;
     const watcher = watch(
       libPath,
       { recursive: true },
@@ -182,7 +182,7 @@ registerCallHandler<[MusicLibraries, number], [boolean]>(
   "musiclibrary.addLibrary",
   async (_event, library) => {
     const libPath = getLibraryPath(library);
-    if (!libPath) return [true];
+    if (!libPath || !existsSync(libPath)) return [true];
     const db = getMusicLibraryDb();
 
     const entries = await readdir(libPath, { recursive: true });


### PR DESCRIPTION
NCM在接收路径后会替换为 Windows 分隔符，现在归一化确保能找到路径

close #142 