### PR TITLE
修复配置的代理服务器未被使用

### DIFF
--- a/src/main/anonymous.ts
+++ b/src/main/anonymous.ts
@@ -10,7 +10,7 @@ import { randomBytes } from "node:crypto";
 
 import type { NetworkFetchRequest } from "./calls/network";
 import { deserialData, encodeAnonymousId } from "./crypto";
-import client from "./request";
+import { client } from "./request";
 
 const ANONYMOUS_REGISTER_PATH = "/api/register/anonimous";
 const ANONYMOUS_EAPI_REGISTER_PATH = "/eapi/register/anonimous";

--- a/src/main/audio/DownloadScheduler.ts
+++ b/src/main/audio/DownloadScheduler.ts
@@ -1,11 +1,10 @@
-import got from "got";
-
 import { toError } from "../../util";
+import { client } from "../request";
 
 import type ChunkTracker from "./ChunkTracker";
 import type StorageManager from "./StorageManager";
 
-type GotStream = ReturnType<typeof got.stream>;
+type GotStream = ReturnType<typeof client.stream>;
 
 const BACKGROUND_RETRY_MIN_DELAY = 1000;
 const BACKGROUND_RETRY_MAX_DELAY = 15_000;
@@ -322,7 +321,7 @@ export default class DownloadScheduler {
 
     let offset = start;
     let stopReason: "abort" | "collision" | null = null;
-    const request = got.stream(this.url, {
+    const request = client.stream(this.url, {
       headers: {
         Range: `bytes=${start}-${end - 1}`,
       },

--- a/src/main/audio/OnlineStreamer.ts
+++ b/src/main/audio/OnlineStreamer.ts
@@ -5,9 +5,9 @@ import { Readable } from "node:stream";
 import { randomUUID } from "node:crypto";
 
 import Emittery from "emittery";
-import got from "got";
 
 import { toError } from "../../util";
+import { client } from "../request";
 
 import ChunkTracker from "./ChunkTracker";
 import DownloadScheduler from "./DownloadScheduler";
@@ -212,7 +212,7 @@ export class OnlineStreamer extends Emittery<OnlineStreamerEvents> {
   }
 
   private async fetchHeadMetadata(): Promise<SourceMetadata | null> {
-    const response = await got(this.url, {
+    const response = await client(this.url, {
       method: "HEAD",
       throwHttpErrors: false,
       signal: this.metaAbortController.signal,
@@ -234,7 +234,7 @@ export class OnlineStreamer extends Emittery<OnlineStreamerEvents> {
 
   private fetchRangeMetadata(): Promise<SourceMetadata> {
     return new Promise((resolve, reject) => {
-      const request = got.stream(this.url, {
+      const request = client.stream(this.url, {
         headers: {
           Range: "bytes=0-0",
         },

--- a/src/main/calls/app.ts
+++ b/src/main/calls/app.ts
@@ -17,7 +17,7 @@ import { pngFromIco } from "../util";
 import packManager from "../pack";
 import { kv as settings } from "../settings";
 import type { ProxyConfiguration, ProxyTypes } from "../request";
-import client, { getProxyAgent } from "../request";
+import { client, getProxyAgent } from "../request";
 import { disableHardwareAccelerationFlag } from "../folders";
 import { LifecycleState, setLifecycleState } from "../lifecycle";
 

--- a/src/main/calls/network.ts
+++ b/src/main/calls/network.ts
@@ -5,7 +5,7 @@ import type { Method } from "got";
 
 import { registerCallHandler } from "../calls";
 import { deserialData } from "../crypto";
-import client from "../request";
+import { client } from "../request";
 import interceptAnonymousRequest from "../anonymous";
 
 let globalFailCount = 0;

--- a/src/main/calls/process.ts
+++ b/src/main/calls/process.ts
@@ -7,7 +7,7 @@ import type { Progress } from "got";
 
 import { registerCallHandler } from "../calls";
 import { serialData } from "../crypto";
-import client, { type ProxyTypes } from "../request";
+import { client, type ProxyTypes } from "../request";
 import { normalizePath } from "../util";
 import { basename, extname } from "node:path";
 

--- a/src/main/download.ts
+++ b/src/main/download.ts
@@ -6,7 +6,7 @@ import type { WriteStream } from "node:fs";
 import type { Request } from "got";
 import Emittery from "emittery";
 
-import client from "./request";
+import { client } from "./request";
 
 export type DownloadStartOptions = {
   headers?: Record<string, string>;

--- a/src/main/orpheus.ts
+++ b/src/main/orpheus.ts
@@ -11,7 +11,7 @@ import packManager from "./pack";
 import WebPack from "./packs/WebPack";
 import { sanitizeRelativePath } from "./util";
 import { data as dataDir, storage as storageDir, wasm } from "./folders";
-import client from "./request";
+import { client } from "./request";
 
 class NetworkError extends Error {
   constructor(message: string, options?: ErrorOptions) {

--- a/src/main/request.ts
+++ b/src/main/request.ts
@@ -86,7 +86,7 @@ export async function getProxyAgent(
   }
 }
 
-let client: Got = got.extend({
+export let client: Got = got.extend({
   headers: {
     // We get User-Agent from Electron, so make sure this module is only imported after app ready.
     "User-Agent": session.defaultSession.getUserAgent(),
@@ -107,8 +107,6 @@ let client: Got = got.extend({
     ],
   },
 });
-
-export default client;
 
 export function setProxy(agents: Agents | undefined) {
   client = client.extend({


### PR DESCRIPTION
#129 之后 vite 升级导致编译结果发生变化，网络请求拿到的 client 是配置代理前的对象未被改变

#120 改音频请求为直接用 got ，这个 pr 修改 audio 处网络请求从直接用 got 改为复用 client 是为了防止走代理时音频获取过程 500
<img width="455" height="176" alt="image" src="https://github.com/user-attachments/assets/dc9458d7-a48f-41b7-a3fc-31bfe0656399" />
<img width="427" height="82" alt="image" src="https://github.com/user-attachments/assets/ab09121f-2500-4a33-a525-e9a84ad70d8a" />

