### PR TITLE
为菜单窗口添加标题

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -268,6 +268,7 @@ export default class AppMenu extends Emittery<AppMenuEvents> {
       });
 
       const sub = new BrowserWindow({
+        title: "Open Orpheus Menu",
         show: false,
         frame: false,
         transparent: true,

--- a/src/main/menu/windows.ts
+++ b/src/main/menu/windows.ts
@@ -11,6 +11,7 @@ export function createMenuWindow(): BrowserWindow {
   }
 
   menuWindow = new BrowserWindow({
+    title: "Open Orpheus Menu",
     width: 300,
     height: 400,
     show: false,
@@ -47,6 +48,7 @@ export function createOverlayWindow(): BrowserWindow {
   }
 
   overlayWindow = new BrowserWindow({
+    title: "Open Orpheus Menu",
     x: 0,
     y: 0,
     frame: false,


### PR DESCRIPTION
标题：`Open Orpheus Menu`
允许用户对菜单窗口添加 WM 规则（如 KDE 窗口规则）以提升使用体验