### PR TITLE
修复部分 Cookie 在启动时不存在的问题

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -256,7 +256,10 @@ app.on("ready", async () => {
           console.warn("Failed to get proxy configuration", err);
         }
       }),
-      prepareDeviceId(),
+      prepareDeviceId().then(async () => {
+        // Initialize initial cookies
+        await (await import("./main/cookie")).default();
+      }),
       packManager.getPack<WebPack>("web").readPack(),
       import("./main/windows/desktop-lyrics").then((m) => {
         // Create desktop lyrics window

--- a/src/main/cookie.ts
+++ b/src/main/cookie.ts
@@ -1,6 +1,9 @@
 import { session } from "electron";
 import * as cookie from "cookie";
 
+import { getADDeviceId, getDeviceId } from "./device";
+import { CORE_VERSION, OSVER } from "../constants";
+
 const cookies = session.defaultSession.cookies;
 
 export async function getFullCookies(url: string) {
@@ -38,4 +41,31 @@ export async function setCookie(url: string, setCookieValue: cookie.SetCookie) {
             ? "no_restriction"
             : setCookieValue.sameSite,
   });
+}
+
+/**
+ * Initializes the cookies.
+ *
+ * Some cookies are required to be inserted ahead of time, this function will do the job.
+ */
+export default async function initializeCookies() {
+  const initialCookies: Record<string, string> = {
+    os: "pc",
+    deviceId: getDeviceId(),
+    osver: OSVER,
+    appver: CORE_VERSION,
+    clientSign: getADDeviceId(),
+  };
+
+  await Promise.all(
+    Object.entries(initialCookies).map(async ([cookie, value]) => {
+      await cookies.set({
+        name: cookie,
+        value,
+        url: "https://music.163.com",
+        domain: ".music.163.com",
+        path: "/",
+      });
+    })
+  );
 }


### PR DESCRIPTION
根据对目标实现的反复观察，有些 Cookie 需要在启动时提前注入，以确保部分功能正常

close #177 