### PR TITLE
修复桌面歌词难以调整大小

### DIFF
--- a/gui/src/routes/(transparent)/desktop-lyrics/+page.svelte
+++ b/gui/src/routes/(transparent)/desktop-lyrics/+page.svelte
@@ -183,7 +183,6 @@
         enableFullInteraction = false;
       }, 1000);
     }}
-    {@attach enableFullInteraction && !locked && inputRegionAttachment}
   >
     <div
       class="flex justify-center gap-2 {locked
@@ -241,7 +240,8 @@
         enableFullInteraction = true;
       }}
       lineattrs={{
-        [createAttachmentKey()]: !locked && inputRegionAttachment,
+        [createAttachmentKey()]:
+          !enableFullInteraction && !locked && inputRegionAttachment,
         [createAttachmentKey()]: lineHoverAttachment,
       }}
     />


### PR DESCRIPTION
#213 中因交互区调整，被限制到根容器而不是整个窗口，导致通过边框交互调整大小极其困难

Linux 下因 https://github.com/electron/electron/issues/52452 完全无法调整大小，故暂且不因此修复受益