### PR TITLE
feat: support NetEase extended JSON LRC lines

### DIFF
--- a/src/main/lyrics/parse.ts
+++ b/src/main/lyrics/parse.ts
@@ -25,6 +25,39 @@ function parseTimestamp(tag: string): number | null {
 }
 
 /**
+ * Parse a NetEase extended LRC line such as
+ * `{"t":0,"c":[{"tx":"作曲："},{"tx":"玉屋2060%"}]}`.
+ *
+ * `t` is the timestamp in milliseconds and `c` is a rich-text array whose
+ * actual text is the concatenation of each `tx` field. Returns `null` when
+ * the line is not a recognized NetEase JSON lyric entry.
+ */
+export function parseNeteaseJsonLyricLine(
+  line: string
+): { time: number; text: string } | null {
+  if (!line.startsWith("{")) return null;
+
+  let parsed: { t?: unknown; c?: unknown };
+  try {
+    parsed = JSON.parse(line) as { t?: unknown; c?: unknown };
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed.t !== "number" || !Array.isArray(parsed.c)) return null;
+
+  const text = parsed.c
+    .map((segment) => {
+      if (typeof segment !== "object" || segment === null) return "";
+      const tx = (segment as { tx?: unknown }).tx;
+      return typeof tx === "string" ? tx : "";
+    })
+    .join("");
+
+  return { time: parsed.t, text };
+}
+
+/**
  * Parse an LRC string into {@link Lyrics}.
  *
  * Each `[mm:ss.xx]` line becomes a {@link LyricsLine} with a single
@@ -40,6 +73,12 @@ export function parseLrc(lrc: string): Lyrics {
   for (const raw of lrc.split("\n")) {
     const line = raw.trim();
     if (!line) continue;
+
+    const jsonEntry = parseNeteaseJsonLyricLine(line);
+    if (jsonEntry) {
+      entries.push(jsonEntry);
+      continue;
+    }
 
     // Collect all tags at the start of the line
     const times: number[] = [];


### PR DESCRIPTION
## 摘要

处理网易云返回的非标准 LRC：部分歌词行是 `{"t":<毫秒>,"c":[{"tx":"..."},...]}` 的 JSON 富文本格式，当前 `parseLrc` 会直接跳过这些行，导致这类歌词无法显示。

本 PR 在 `src/main/lyrics/parse.ts` 中新增 `parseNeteaseJsonLyricLine`，将 `t` 作为毫秒时间戳、拼接 `c[].tx` 作为歌词文本，并接入 `parseLrc`。标准 LRC 行、多时间戳行、非法 JSON 行的行为保持不变。

## 验证

- `pnpm lint:types:root` 通过
- `pnpm exec eslint src/main/lyrics/parse.ts` 通过
- `pnpm exec prettier --check src/main/lyrics/parse.ts` 通过
- 用 issue 中的示例数据（`t` 为 0/788/1576 ms 的 JSON 行 + 标准 LRC 行）验证解析结果正确

## AI 协助披露

本 PR 由 Codex（OpenAI）协助编写和验证。

Closes #25
