### PR TITLE
修复代理设置没有完全应用

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -234,6 +234,15 @@ app.on("ready", async () => {
       import("./main/request").then(async (m) => {
         m.setupRequestInterceptors();
 
+        // Set the proxy for both the app and our sessions
+        const setProxy = async (config: Parameters<typeof app.setProxy>[0]) => {
+          await Promise.all([
+            app.setProxy(config),
+            session.defaultSession.setProxy(config),
+            openOrpheusSession.setProxy(config),
+          ]);
+        };
+
         // Apply stored proxy settings
         const { kv: settings } = await import("./main/settings");
         const proxy = await settings.get("proxy");
@@ -244,13 +253,13 @@ app.on("ready", async () => {
 
           switch (cfg.Type) {
             case "ie":
-              app.setProxy({ mode: "system" });
+              await setProxy({ mode: "system" });
               break;
             case "http":
             case "socks4":
             case "socks5": {
               const srv = cfg[cfg.Type]!;
-              app.setProxy({
+              await setProxy({
                 mode: "fixed_servers",
                 proxyRules: `${cfg.Type}://${srv.Host}:${srv.Port}`,
               });
@@ -264,7 +273,7 @@ app.on("ready", async () => {
               break;
             }
             default:
-              app.setProxy({ mode: "direct" });
+              await setProxy({ mode: "direct" });
               break;
           }
 


### PR DESCRIPTION
问题：在网易云音乐设置中配置代理后，只有主进程 got 发的请求（API 之类的）走了代理，网易云自己的所有请求却全部是走直连的。设置代理后 sing-box 中能看到大量的到 music.126.net 的请求是直接由 electron43 发出的，而不是由设置的代理服务器发出。

原因：main.ts 只调了 app.setProxy()，它只作用于不关联 session 的请求，覆盖不到 session.defaultSession 和 open-orpheus partition。

改动：封装了一个函数 setProxy，同时设置这三个作用域的代理。

验证：sing-box 中到 music.126.net 的请求全部由代理服务器发出，设置 unlock 服务器之后可以正常听灰歌和 vip 歌，unlock 代理服务器的终端中也有获取音乐的日志。