### PR TITLE
修复退出时偶尔出现的日志流未捕获异常

### DIFF
--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -221,11 +221,19 @@ if (process.stdout.isTTY)
     options: {},
   });
 
-const logger = pino(
-  pino.transport({
-    targets: transport,
-  })
-);
+const stream = pino.transport({
+  targets: transport,
+});
+
+stream.addListener("error", (e) => {
+  try {
+    console.log("Log stream error", e);
+  } catch {
+    // Hmm, we are lost
+  }
+});
+
+const logger = pino(stream);
 
 ipcMain.on(
   "logger.log",


### PR DESCRIPTION
有时候退出的时候当thread-stream退出worker时有日志出现会导致stream抛出错误，导致uncaughtException