### PR TITLE
修复 Linux 下 MPRIS 上报播放器状态错误

### DIFF
--- a/modules/dbus/src/media_session/mpris.rs
+++ b/modules/dbus/src/media_session/mpris.rs
@@ -336,21 +336,11 @@ impl PlayerInterface {
     #[zbus(property)]
     async fn can_play(&self) -> bool {
         self.metadata.is_some()
-            & self
-                .playback_state
-                .as_ref()
-                .map(|x| x.status != PlaybackStatus::Playing)
-                .unwrap_or(true)
     }
 
     #[zbus(property)]
     async fn can_pause(&self) -> bool {
         self.metadata.is_some()
-            & self
-                .playback_state
-                .as_ref()
-                .map(|x| x.status != PlaybackStatus::Playing)
-                .unwrap_or(false)
     }
 
     #[zbus(property)]


### PR DESCRIPTION
参见：
https://specifications.freedesktop.org/mpris/latest/Player_Interface.html#Property:CanPlay
https://specifications.freedesktop.org/mpris/latest/Player_Interface.html#Property:CanPause

> its value should not depend on whether the track is currently paused or playing. In fact, if playback is currently playing/paused (and [CanControl](https://specifications.freedesktop.org/mpris/latest/Player_Interface.html#Property:CanControl) is true), this should be true.

若当前上报状态和播放状态一致会导致 playerctl 无法使用
```bash
> G_MESSAGES_DEBUG=all playerctl -p open-orpheus metadata             
** (process:224226): DEBUG: 14:14:15.488: playerctl version 2.4.1
(playerctl:224226): playerctl-DEBUG: 14:14:15.496: Getting list of player names from D-Bus
(playerctl:224226): playerctl-DEBUG: 14:14:15.497: Getting list of player names from D-Bus
** (playerctl:224226): DEBUG: 14:14:15.497: found player: open-orpheus
(playerctl:224226): playerctl-DEBUG: 14:14:15.511: initializing player: open-orpheus
** (playerctl:224226): DEBUG: 14:14:15.511: executing command metadata
** (playerctl:224226): DEBUG: 14:14:15.511: metadata command for player: open-orpheus
** (playerctl:224226): DEBUG: 14:14:15.511: open-orpheus: can-play is false, skipping
** (playerctl:224226): DEBUG: 14:14:15.511: found player: kdeconnect.mpris_c80b504075374bd9a5c0f1bffe35da66
No player could handle this command

> G_MESSAGES_DEBUG=all playerctl -p open-orpheus play-pause
** (process:245343): DEBUG: 14:48:26.420: playerctl version 2.4.1
(playerctl:245343): playerctl-DEBUG: 14:48:26.428: Getting list of player names from D-Bus
(playerctl:245343): playerctl-DEBUG: 14:48:26.428: Getting list of player names from D-Bus
** (playerctl:245343): DEBUG: 14:48:26.429: found player: open-orpheus
(playerctl:245343): playerctl-DEBUG: 14:48:26.430: initializing player: open-orpheus
** (playerctl:245343): DEBUG: 14:48:26.430: executing command play-pause
** (playerctl:245343): DEBUG: 14:48:26.430: open-orpheus: can-play is false, skipping
** (playerctl:245343): DEBUG: 14:48:26.430: found player: kdeconnect.mpris_c80b504075374bd9a5c0f1bffe35da66
No player could handle this command
```