### PR TITLE
Updates: Update an Pack for ArchLinux（上传了一个直接通过git clone的编译方法）

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,125 @@
+# Maintainer: YUCLing <luotianyi@luotianyi.me>
+# Contributor: Yose Lok <xiaolongbao@ngny0n.top>
+
+pkgname=open-orpheus
+pkgver=0.16.2
+pkgrel=1
+pkgdesc="An open-source implementation of Netease Cloud Music's Orpheus browser host"
+arch=('x86_64')
+url="https://github.com/YUCLing/open-orpheus"
+license=('MIT')
+_srcname=open-orpheus
+provides=('open-orpheus')
+conflicts=('open-orpheus-bin' 'open-orpheus-git')
+depends=(
+    'alsa-lib'
+    'at-spi2-core'
+    'gtk3'
+    'hicolor-icon-theme'
+    'libdrm'
+    'libnotify'
+    'libxcb'
+    'mesa'
+    'nss'
+    'xdg-utils'
+)
+optdepends=('kde-cli-tools: enable trash integration')
+makedepends=(
+    'git'
+    'pnpm'
+    'python'
+    'rust'
+    'rust-wasm'
+    'wasm-bindgen'
+)
+source=(
+    "${_srcname}::git+https://gh-proxy.org/https://github.com/YUCLing/open-orpheus.git#tag=v${pkgver}"
+)
+sha256sums=('SKIP')
+
+prepare() {
+    cd "${srcdir}/${_srcname}"
+    
+    # 设置 Rust 环境变量（支持自定义安装路径）
+    export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
+    export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+    export PATH="$CARGO_HOME/bin:$PATH"
+    
+    # 确保 Rust 默认工具链已设置
+    if ! rustup show active-toolchain &>/dev/null; then
+        echo "Setting up Rust default toolchain..."
+        rustup default stable
+    fi
+    
+    # 安装 pnpm 依赖
+    echo "Installing pnpm dependencies..."
+    pnpm install --frozen-lockfile
+}
+
+build() {
+    cd "${srcdir}/${_srcname}"
+    
+    # 设置 Rust 环境变量
+    export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
+    export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+    export PATH="$CARGO_HOME/bin:$PATH"
+    
+    # 确保 wasm 目标已安装
+    echo "Ensuring wasm32 target is installed..."
+    rustup target add wasm32-unknown-unknown
+    
+    # 构建原生模块
+    echo "Building native modules..."
+    pnpm build:modules
+    
+    # 打包 Electron 应用
+    echo "Packaging Electron application..."
+    pnpm package
+}
+
+package() {
+    local appdir="${srcdir}/${_srcname}/out/${_srcname}-linux-x64"
+    
+    # 创建安装目录
+    install -d "${pkgdir}/usr/lib/${_srcname}"
+    
+    # 复制应用文件
+    cp -a "${appdir}/." "${pkgdir}/usr/lib/${_srcname}/"
+    
+    # 修复权限
+    chmod -R a+rX "${pkgdir}/usr/lib/${_srcname}"
+    
+    # 创建 bin 目录并生成启动脚本
+    install -d "${pkgdir}/usr/bin"
+    cat > "${pkgdir}/usr/bin/${_srcname}" << 'EOF'
+#!/bin/bash
+exec /usr/lib/open-orpheus/open-orpheus "$@"
+EOF
+    chmod 755 "${pkgdir}/usr/bin/${_srcname}"
+    
+    # 创建 applications 目录并生成桌面文件
+    install -d "${pkgdir}/usr/share/applications"
+    cat > "${pkgdir}/usr/share/applications/${_srcname}.desktop" << EOF
+[Desktop Entry]
+Name=Open Orpheus
+Comment=${pkgdesc}
+Exec=${_srcname} %U
+Icon=${_srcname}
+Terminal=false
+Type=Application
+Categories=Audio;Music;Player;
+MimeType=x-scheme-handler/netease-cloud-music;
+EOF
+    
+    # 安装图标（如果存在）
+    if [ -f "${srcdir}/${_srcname}/assets/icon_512.png" ]; then
+        install -Dm644 "${srcdir}/${_srcname}/assets/icon_512.png" \
+            "${pkgdir}/usr/share/icons/hicolor/512x512/apps/${_srcname}.png"
+    fi
+    
+    # 安装许可证
+    install -Dm644 "${srcdir}/${_srcname}/LICENSE" \
+        "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+    
+    echo "华风夏韵，洛水天依"
+}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=open-orpheus
 pkgver=0.16.2
-pkgrel=1
+pkgrel=3
 pkgdesc="An open-source implementation of Netease Cloud Music's Orpheus browser host"
 arch=('x86_64')
 url="https://github.com/YUCLing/open-orpheus"
@@ -23,7 +23,10 @@ depends=(
     'nss'
     'xdg-utils'
 )
-optdepends=('kde-cli-tools: enable trash integration')
+optdepends=(
+    'kde-cli-tools: enable trash integration'
+    'gnome-shell-extension-just-perfection: Recommended for hiding title bars on mini player'
+)
 makedepends=(
     'git'
     'pnpm'
@@ -40,18 +43,6 @@ sha256sums=('SKIP')
 prepare() {
     cd "${srcdir}/${_srcname}"
     
-    # 设置 Rust 环境变量（支持自定义安装路径）
-    export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
-    export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
-    export PATH="$CARGO_HOME/bin:$PATH"
-    
-    # 确保 Rust 默认工具链已设置
-    if ! rustup show active-toolchain &>/dev/null; then
-        echo "Setting up Rust default toolchain..."
-        rustup default stable
-    fi
-    
-    # 安装 pnpm 依赖
     echo "Installing pnpm dependencies..."
     pnpm install --frozen-lockfile
 }
@@ -59,20 +50,12 @@ prepare() {
 build() {
     cd "${srcdir}/${_srcname}"
     
-    # 设置 Rust 环境变量
-    export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
-    export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
-    export PATH="$CARGO_HOME/bin:$PATH"
+    export ELECTRON_MIRROR="https://npmmirror.com/mirrors/electron/"
+    export ELECTRON_GET_TIMEOUT=300000
     
-    # 确保 wasm 目标已安装
-    echo "Ensuring wasm32 target is installed..."
-    rustup target add wasm32-unknown-unknown
-    
-    # 构建原生模块
     echo "Building native modules..."
     pnpm build:modules
     
-    # 打包 Electron 应用
     echo "Packaging Electron application..."
     pnpm package
 }
@@ -80,24 +63,21 @@ build() {
 package() {
     local appdir="${srcdir}/${_srcname}/out/${_srcname}-linux-x64"
     
-    # 创建安装目录
     install -d "${pkgdir}/usr/lib/${_srcname}"
-    
-    # 复制应用文件
     cp -a "${appdir}/." "${pkgdir}/usr/lib/${_srcname}/"
-    
-    # 修复权限
     chmod -R a+rX "${pkgdir}/usr/lib/${_srcname}"
     
-    # 创建 bin 目录并生成启动脚本
     install -d "${pkgdir}/usr/bin"
     cat > "${pkgdir}/usr/bin/${_srcname}" << 'EOF'
 #!/bin/bash
-exec /usr/lib/open-orpheus/open-orpheus "$@"
+export NCM_OZONE_PLATFORM_HINT="auto"
+exec /usr/lib/open-orpheus/open-orpheus \
+    --ozone-platform-hint=auto \
+    --enable-features=UseOzonePlatform,WaylandWindowDecorations \
+    "$@"
 EOF
     chmod 755 "${pkgdir}/usr/bin/${_srcname}"
     
-    # 创建 applications 目录并生成桌面文件
     install -d "${pkgdir}/usr/share/applications"
     cat > "${pkgdir}/usr/share/applications/${_srcname}.desktop" << EOF
 [Desktop Entry]
@@ -109,17 +89,14 @@ Terminal=false
 Type=Application
 Categories=Audio;Music;Player;
 MimeType=x-scheme-handler/netease-cloud-music;
+StartupWMClass=open-orpheus
 EOF
     
-    # 安装图标（如果存在）
     if [ -f "${srcdir}/${_srcname}/assets/icon_512.png" ]; then
         install -Dm644 "${srcdir}/${_srcname}/assets/icon_512.png" \
             "${pkgdir}/usr/share/icons/hicolor/512x512/apps/${_srcname}.png"
     fi
     
-    # 安装许可证
     install -Dm644 "${srcdir}/${_srcname}/LICENSE" \
         "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
-    
-    echo "华风夏韵，洛水天依"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -34,6 +34,7 @@ makedepends=(
     'rust'
     'rust-wasm'
     'wasm-bindgen'
+    'rustup'
 )
 source=(
     "${_srcname}::git+https://gh-proxy.org/https://github.com/YUCLing/open-orpheus.git#tag=v${pkgver}"


### PR DESCRIPTION
本更新仅添加了一个PKGBUILD，PKGBUILD仅通过clone源仓库以安装，而不同于AUR仓库上的PKGBUILD（下载releases的tar安装）
每次更新时需更新pkgver=当前更新版本。